### PR TITLE
Bytt ut typpe med aarsak og bruk Transformer til å være bakoverkompatibel

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/Inntekt.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/Inntekt.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.Serializable
 data class Inntekt(
     val bekreftet: Boolean,
     val beregnetInntekt: Double,
+    @Serializable(with = InntektEndringAarsakTransformer::class)
     val endringÅrsak: InntektEndringAarsak? = null,
     val manueltKorrigert: Boolean,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/InntektEndringAarsak.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/InntektEndringAarsak.kt
@@ -23,9 +23,10 @@ sealed class InntektEndringAarsak
 object InntektEndringAarsakTransformer : JsonTransformingSerializer<InntektEndringAarsak>(InntektEndringAarsak.serializer()) {
     override fun transformDeserialize(element: JsonElement): JsonElement {
         if (element is JsonObject && element.containsKey("typpe")) {
-            val mutableMap = element.toMutableMap()
-            mutableMap["aarsak"] = mutableMap.remove("typpe")!!
-            return JsonObject(mutableMap)
+            val gammelJson = element.toMap()
+            val aarsak = gammelJson["typpe"] ?: throw IllegalArgumentException("Mangler felt 'typpe'.")
+            val nyJson = gammelJson.minus("typpe").plus("aarsak" to aarsak)
+            return JsonObject(nyJson)
         }
         return element
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/InntektEndringAarsak.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/InntektEndringAarsak.kt
@@ -5,7 +5,6 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonClassDiscriminator
 import kotlinx.serialization.json.JsonElement
@@ -19,7 +18,6 @@ import java.time.LocalDate
 @JsonClassDiscriminator("aarsak")
 sealed class InntektEndringAarsak
 
-@Serializer(forClass = InntektEndringAarsak::class)
 object InntektEndringAarsakTransformer : JsonTransformingSerializer<InntektEndringAarsak>(InntektEndringAarsak.serializer()) {
     override fun transformDeserialize(element: JsonElement): JsonElement {
         if (element is JsonObject && element.containsKey("typpe")) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/InntektEndringAarsak.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/InntektEndringAarsak.kt
@@ -5,16 +5,31 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonClassDiscriminator
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonTransformingSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import java.time.LocalDate
 
 @Serializable
 @OptIn(ExperimentalSerializationApi::class)
-// TODO bytt ved mulighet
-@JsonClassDiscriminator("typpe")
+@JsonClassDiscriminator("aarsak")
 sealed class InntektEndringAarsak
+
+@Serializer(forClass = InntektEndringAarsak::class)
+object InntektEndringAarsakTransformer : JsonTransformingSerializer<InntektEndringAarsak>(InntektEndringAarsak.serializer()) {
+    override fun transformDeserialize(element: JsonElement): JsonElement {
+        if (element is JsonObject && element.containsKey("typpe")) {
+            val mutableMap = element.toMutableMap()
+            mutableMap["aarsak"] = mutableMap.remove("typpe")!!
+            return JsonObject(mutableMap)
+        }
+        return element
+    }
+}
 
 @Serializable
 @SerialName("Bonus")

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/TyppeTilAarsakKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/TyppeTilAarsakKtTest.kt
@@ -1,0 +1,30 @@
+package no.nav.helsearbeidsgiver.domene.inntektsmelding
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+
+class TyppeTilAarsakKtTest : FunSpec({
+    context("sjekk at Inntekt objekt blir serialisert og deserialisert riktig") {
+        test("Json string med typpe verdi blir deserialisert til Inntekt objekt") {
+            Json.decodeFromString(Inntekt.serializer(), Mock.typpeJson) shouldBe Mock.gyldigInntekt
+        }
+        test("Json string med aarsak verdi blir deserialisert til Inntekt objekt") {
+            Json.decodeFromString(Inntekt.serializer(), Mock.aarsakJson) shouldBe Mock.gyldigInntekt
+        }
+        test("Inntekt blir serialisert til Json string med aarsak verdi") {
+            Json.encodeToString(Inntekt.serializer(), Mock.gyldigInntekt) shouldBe Mock.aarsakJson
+        }
+    }
+})
+
+object Mock {
+    val typpeJson = """{"bekreftet":true,"beregnetInntekt":1000.0,"endringÅrsak":{"typpe":"Nyansatt"},"manueltKorrigert":false}"""
+    val aarsakJson = """{"bekreftet":true,"beregnetInntekt":1000.0,"endringÅrsak":{"aarsak":"Nyansatt"},"manueltKorrigert":false}"""
+    val gyldigInntekt = Inntekt(
+        bekreftet = true,
+        beregnetInntekt = 1000.0,
+        endringÅrsak = Nyansatt,
+        manueltKorrigert = false,
+    )
+}


### PR DESCRIPTION
Transformer kan fjernes etter man feks har kjørt et oppdatringscript i databasen. Og alle meldinger på kafka med typpe er lest

feks
```sql
--setter aarsak til typpe verdien
--men beholder fortsatt typpe verdien.
WITH im_temp AS (
    SELECT jsonb_set(dokument, '{inntekt,endringÅrsak,aarsak}', dokument#>'{inntekt,endringÅrsak,typpe}') AS updated_dokument
    FROM inntektsmelding
    WHERE dokument -> 'inntekt' ->> 'endringÅrsak' IS NOT NULL
)
SELECT * FROM im_temp;
```