### PR TITLE
Baser bestemmende fraværsdag på sykdomsperioder ved gap til AGP

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/BestemmendeFravaersdag.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/BestemmendeFravaersdag.kt
@@ -8,19 +8,25 @@ fun bestemmendeFravaersdag(
     arbeidsgiverperioder: List<Periode>,
     egenmeldingsperioder: List<Periode>,
     sykmeldingsperioder: List<Periode>,
-): LocalDate =
-    if (arbeidsgiverperioder.isNotEmpty()) {
+): LocalDate {
+    val sykdomsperioder = egenmeldingsperioder + sykmeldingsperioder
+    val sykdomStart = sykdomsperioder.minOf(Periode::fom)
+
+    val agpSlutt = arbeidsgiverperioder.maxOfOrNull(Periode::tom)
+
+    return if (agpSlutt != null && agpSlutt.daysUntil(sykdomStart) <= 1) {
         arbeidsgiverperioder
             .slaaSammenPerioder { denne, neste ->
                 denne.tom.daysUntil(neste.fom) <= 1
             }
     } else {
-        (egenmeldingsperioder + sykmeldingsperioder)
+        sykdomsperioder
             .slaaSammenPerioder(
                 kanSlaasSammen = ::kanSlaasSammenIgnorerHelgegap,
             )
     }
         .fom
+}
 
 private fun List<Periode>.slaaSammenPerioder(
     kanSlaasSammen: (Periode, Periode) -> Boolean,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/BestemmendeFravaersdagKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/BestemmendeFravaersdagKtTest.kt
@@ -112,10 +112,7 @@ class BestemmendeFravaersdagKtTest : FunSpec({
         }
 
         test("arbeidsgiverperiode med gap til egenmeldingsperioder") {
-            // Kommenter inn når logikk endres til å velge fom fra egenmeldingsperioder
-//            val expected = 3.februar
-
-            val expected = 10.januar
+            val expected = 3.februar
 
             val actual = bestemmendeFravaersdag(
                 arbeidsgiverperioder = listOf(
@@ -133,10 +130,7 @@ class BestemmendeFravaersdagKtTest : FunSpec({
         }
 
         test("arbeidsgiverperiode med gap til sykmeldingsperioder") {
-            // Kommenter inn når logikk endres til å velge fom fra sykmeldingsperioder
-//            val expected = 8.juni
-
-            val expected = 13.mars
+            val expected = 8.juni
 
             val actual = bestemmendeFravaersdag(
                 arbeidsgiverperioder = listOf(


### PR DESCRIPTION
Dersom AGP ikke overlapper eller er kant i kant med (egenmeldingsperioder + sykmeldingsperioder) så skal man IKKE basere bestemmende fraværsdag på AGP.