### PR TITLE
Legg til ID for type

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -2,6 +2,7 @@
 
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.utils.json.serializer.OffsetDateTimeSerializer
@@ -22,8 +23,16 @@ data class Inntektsmelding(
     val aarsakInnsending: AarsakInnsending,
     val mottatt: OffsetDateTime,
 ) {
-    enum class Type {
-        FORESPURT,
-        SELVBESTEMT,
+    @Serializable
+    sealed class Type {
+        abstract val id: UUID
+
+        @Serializable
+        @SerialName("Forespurt")
+        data class Forespurt(override val id: UUID) : Type()
+
+        @Serializable
+        @SerialName("Selvbestemt")
+        data class Selvbestemt(override val id: UUID) : Type()
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/UtilsTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/UtilsTest.kt
@@ -64,6 +64,7 @@ class UtilsTest : FunSpec({
 
     val dato = LocalDate.of(2023, 1, 1)
     val nyID = UUID.randomUUID()
+    val nyType = InntektsmeldingV1.Type.Forespurt(UUID.randomUUID())
 
     test("convertInntekt") {
         val im = lagGammelInntektsmelding()
@@ -118,7 +119,7 @@ class UtilsTest : FunSpec({
                 utbetalt,
             ),
         )
-        val agp = convertToV1(im_med_reduksjon, nyID, InntektsmeldingV1.Type.FORESPURT).agp
+        val agp = convertToV1(im_med_reduksjon, nyID, nyType).agp
         agp?.redusertLoennIAgp?.beloep shouldBe utbetalt
         agp?.redusertLoennIAgp?.begrunnelse shouldBe BegrunnelseRedusertLoennIAgpV1.BetvilerArbeidsufoerhet
     }
@@ -130,15 +131,15 @@ class UtilsTest : FunSpec({
     }
 
     test("håndterer tomme lister og null-verdier") {
-        val im = convertToV1(lagGammelInntektsmeldingMedTommeOgNullVerdier(), nyID, InntektsmeldingV1.Type.FORESPURT)
+        val im = convertToV1(lagGammelInntektsmeldingMedTommeOgNullVerdier(), nyID, nyType)
         im.aarsakInnsending shouldBe AarsakInnsendingV1.Endring
     }
 
     test("konverter im til V1") {
         val gammelIM = lagGammelInntektsmelding()
-        val nyIM = convertToV1(gammelIM, nyID, InntektsmeldingV1.Type.FORESPURT)
+        val nyIM = convertToV1(gammelIM, nyID, nyType)
 
-        nyIM.type shouldBe InntektsmeldingV1.Type.FORESPURT
+        nyIM.type shouldBe nyType
 
         nyIM.sykmeldt.fnr shouldBe gammelIM.identitetsnummer
         nyIM.sykmeldt.navn shouldBe gammelIM.fulltNavn
@@ -153,7 +154,7 @@ class UtilsTest : FunSpec({
 
     test("konverter fra nytt til gammelt IM-format") {
         val orginal = lagGammelInntektsmelding()
-        val nyIM = convertToV1(orginal, nyID, InntektsmeldingV1.Type.FORESPURT)
+        val nyIM = convertToV1(orginal, nyID, nyType)
         val gammelIM = nyIM.convert()
         gammelIM.shouldBeEqualToIgnoringFields(orginal, Inntektsmelding::inntektsdato, Inntektsmelding::naturalytelser, Inntektsmelding::fullLønnIArbeidsgiverPerioden)
         // konvertering setter inntektsdato til epoch-tid og naturalytelse til tom liste, fullLønnIAgp som null-verdi i orginal blir oversatt til FullLoennIAGP(true, null, null)
@@ -176,7 +177,7 @@ class UtilsTest : FunSpec({
         gammelInntekt?.endringÅrsak shouldBe Feilregistrert
         gammelInntekt?.bekreftet shouldBe true
         gammelInntekt?.manueltKorrigert shouldBe true
-        val nyIM = convertToV1(lagGammelInntektsmelding(), nyID, InntektsmeldingV1.Type.FORESPURT).copy(inntekt = nyInntekt)
+        val nyIM = convertToV1(lagGammelInntektsmelding(), nyID, nyType).copy(inntekt = nyInntekt)
         val konvertert = nyIM.convert()
         konvertert.naturalytelser shouldBe listOf(Naturalytelse(NaturalytelseKode.BEDRIFTSBARNEHAGEPLASS, dato, belop))
         konvertert.inntektsdato shouldBe dato
@@ -187,7 +188,7 @@ class UtilsTest : FunSpec({
         val belop = 333.33
         val periode = listOf(Periode(LocalDate.EPOCH, LocalDate.MAX))
         val egenmeldinger = listOf(Periode(LocalDate.MIN, LocalDate.EPOCH))
-        val nyIM = convertToV1(lagGammelInntektsmelding(), nyID, InntektsmeldingV1.Type.FORESPURT).copy(
+        val nyIM = convertToV1(lagGammelInntektsmelding(), nyID, nyType).copy(
             agp = ArbeidsgiverperiodeV1(
                 periode,
                 egenmeldinger,
@@ -211,7 +212,7 @@ class UtilsTest : FunSpec({
         )
         orginal.convertReduksjon() shouldBe null
 
-        val nyIM = convertToV1(orginal, nyID, InntektsmeldingV1.Type.FORESPURT)
+        val nyIM = convertToV1(orginal, nyID, nyType)
 
         val konvertert = nyIM.convert()
         konvertert.fullLønnIArbeidsgiverPerioden?.begrunnelse shouldBe null
@@ -223,7 +224,7 @@ class UtilsTest : FunSpec({
         val orginal = lagGammelInntektsmelding().copy(
             forespurtData = emptyList(),
         )
-        val nyIM = convertToV1(orginal, nyID, InntektsmeldingV1.Type.FORESPURT)
+        val nyIM = convertToV1(orginal, nyID, nyType)
         nyIM.agp shouldBe null
         nyIM.inntekt shouldBe null
         nyIM.refusjon shouldBe null
@@ -241,9 +242,9 @@ class UtilsTest : FunSpec({
     }
 
     test("generer forespurt data") {
-        val nyIM = convertToV1(lagGammelInntektsmelding(), nyID, InntektsmeldingV1.Type.FORESPURT)
+        val nyIM = convertToV1(lagGammelInntektsmelding(), nyID, nyType)
         nyIM.getForespurtData() shouldBe listOf("arbeidsgiverperiode", "inntekt", "refusjon")
-        val utenFelter = convertToV1(lagGammelInntektsmelding(), nyID, InntektsmeldingV1.Type.FORESPURT).copy(
+        val utenFelter = convertToV1(lagGammelInntektsmelding(), nyID, nyType).copy(
             agp = null,
             refusjon = null,
             inntekt = null,


### PR DESCRIPTION
Original så tenkte jeg at `Inntektsmelding.id` kunne holde forespørsel-/selvbestemt-ID, men legger til en egen `Inntektsmelding.type.id` for å holde dette, så kan `Inntektsmelding.id` holde en ID for selve inntektsmeldingen.

Gustav påpekte at det kunne være gunstig med en egen ID for inntektsmeldinger i forbindelse med eksterne ID-er i journalføring, slik at vi forhindre opprettelse av duplikate journalposter.

Bruker en sealed class slik at vi enkelt kan utvide typen med flere felter som er spesifikke for typen. `vedtaksperiodeId` for forespørsel er mulig og aktuell utvidelse.