### PR TITLE
Bestemmende fraværsdag: Anta sykdom i helg rett etter AGP

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/BestemmendeFravaersdag.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/BestemmendeFravaersdag.kt
@@ -22,10 +22,25 @@ fun bestemmendeFravaersdag(
     ) {
         sammenhengendeSykmeldingsperioder
     } else {
+        val sammenhengendeArbeidsgiverperioder =
+            arbeidsgiverperioder.slaaSammenSammenhengendePerioder(ignorerHelgegap = false)
+
         val sammenhengendeSykmeldingsperioderUtenAgp = sammenhengendeSykmeldingsperioder.fjernDatoerTilOgMed(agpSlutt)
 
-        (arbeidsgiverperioder + sammenhengendeSykmeldingsperioderUtenAgp)
-            .slaaSammenSammenhengendePerioder(ignorerHelgegap = false)
+        // Antar sykdom i helg i overgang fra AGP
+        // Fremtidig versjon: Spør AG om sykdom i helg i overgang
+        val overgangFraAgp = listOf(
+            sammenhengendeArbeidsgiverperioder.last(),
+            sammenhengendeSykmeldingsperioderUtenAgp.first(),
+        )
+            .slaaSammenSammenhengendePerioder(ignorerHelgegap = true)
+
+        listOf(
+            sammenhengendeArbeidsgiverperioder.dropLast(1),
+            overgangFraAgp,
+            sammenhengendeSykmeldingsperioderUtenAgp.drop(1),
+        )
+            .flatten()
             .fjernPerioderEtterFoersteUtoverAgp()
     }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/BestemmendeFravaersdagKtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/BestemmendeFravaersdagKtTest.kt
@@ -201,7 +201,7 @@ class BestemmendeFravaersdagKtTest : FunSpec({
             }
 
             test("arbeidsgiverperioder med helgegap til sykmeldingperioder") {
-                val expected = 5.mars
+                val expected = 2.mars
 
                 val actual = bestemmendeFravaersdag(
                     arbeidsgiverperioder = listOf(
@@ -304,9 +304,9 @@ class BestemmendeFravaersdagKtTest : FunSpec({
             }
 
             test("helgegap mellom arbeidsgiverperioder og sykmeldingsperioder") {
-                // Sykmeldt kan ha vært syk i helgen også, og da er bestemmende fraværsdag 16. august, men
+                // Sykmeldt kan ha vært frisk i helgen også, og da er bestemmende fraværsdag 3. september, men
                 // i dagens løsning har vi ingen måte å vite dette på
-                val expected = 3.september
+                val expected = 16.august
 
                 val actual = bestemmendeFravaersdag(
                     arbeidsgiverperioder = listOf(
@@ -314,6 +314,7 @@ class BestemmendeFravaersdagKtTest : FunSpec({
                         16.august til 31.august,
                     ),
                     sykmeldingsperioder = listOf(
+                        16.august til 24.august,
                         3.september til 21.september,
                     ),
                 )


### PR DESCRIPTION
Dette er en endring i antagelsen vi gjør om sykdom i helg rett etter AGP. Etter hvert må vi innhente mer informasjon slik at vi slipper å gjøre denne antagelsen.