### PR TITLE
legger til boolean selvbestemt i journalførtInntektsmelding så spino vet / håndterer dette

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - dev/**
 
 jobs:
   build_and_test:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - dev/**
 
 jobs:
   build_and_test:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,33 @@
+name: Publish Snapshot
+
+on:
+  workflow_run:
+    workflows: [Build and test]
+    types: [completed]
+    branches:
+      - dev/**
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Publish artifact
+        run: |
+          NEW_VERSION=$(echo ${version}-"${GITHUB_SHA}")
+          echo "New version: ${NEW_VERSION}"
+          ./gradlew -Pversion=${NEW_VERSION} publish
+        env:
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -20,8 +20,10 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-
+      - name: Get Version
+        run: echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
       - name: Publish artifact
         run: ./gradlew publish
+        if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   publish-snapshot:
+    env:
+      ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -24,10 +26,6 @@ jobs:
         run:  |
           echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)"
           echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV
-        env:
-          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish artifact
         if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
         run: ./gradlew publish
-        env:
-          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -6,24 +6,6 @@ on:
       - dev/**
 
 jobs:
-  build_and_test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: temurin
-          cache: gradle
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Build and test
-        run: ./gradlew build test
-        env:
-          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
-
   publish-snapshot:
     runs-on: ubuntu-latest
     permissions:
@@ -40,9 +22,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Publish artifact
-        run: |
-          NEW_VERSION=$(echo ${version}-"${GITHUB_SHA}")
-          echo "New version: ${NEW_VERSION}"
-          ./gradlew -Pversion=${NEW_VERSION} publish
+        run: ./gradlew publish
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,9 +21,11 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Get Version
+        run:  |
+          echo "CURRENT_VERSION=$(./gradlew :printVersion)"
+          echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
-        run: echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
       - name: Publish artifact
         if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
         run: ./gradlew publish

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -22,8 +22,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Get Version
         run:  |
-          echo "CURRENT_VERSION=$(./gradlew :printVersion)"
-          echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
+          echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)"
+          echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish artifact

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Get Version
+        env:
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
         run: echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
       - name: Publish artifact
         if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,10 +21,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Get Version
-        run: |
-          echo "MY_VERSION=$(./gradlew :printVersion)" >> "$GITHUB_ENV"
+        run: echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
       - name: Publish artifact
+        if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
         run: ./gradlew publish
-        if: ${{ endsWith($MY_VERSION, '-SNAPSHOT') }}
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,18 +1,33 @@
 name: Publish Snapshot
 
 on:
-  workflow_run:
-    workflows: [Build and test]
-    types: [completed]
+  push:
     branches:
       - dev/**
 
 jobs:
-  publish:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: gradle
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build and test
+        run: ./gradlew build test
+        env:
+          ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-snapshot:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v3

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Get Version
-        run: echo "CURRENT_VERSION=$(./gradlew :printVersion)" >> $GITHUB_ENV
+        run: |
+          echo "MY_VERSION=$(./gradlew :printVersion)" >> "$GITHUB_ENV"
       - name: Publish artifact
         run: ./gradlew publish
-        if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
+        if: ${{ endsWith($MY_VERSION, '-SNAPSHOT') }}
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.18-SNAPSHOT"
+
 
 plugins {
     kotlin("jvm")
@@ -20,6 +20,10 @@ tasks {
     test {
         useJUnitPlatform()
     }
+}
+
+tasks.register("printVersion") {
+    printVersion()
 }
 
 java {
@@ -68,6 +72,6 @@ fun RepositoryHandler.mavenNav(repo: String): MavenArtifactRepository {
     }
 }
 
-fun printVersionName() {
-    println (version)
+fun printVersion() {
+    println(version)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,6 +71,5 @@ fun RepositoryHandler.mavenNav(repo: String): MavenArtifactRepository {
     }
 }
 
-fun printVersion() {
-    println(version)
-}
+fun printVersion() = println(version)
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.18"
+version = "0.0.18-SNAPSHOT"
 
 plugins {
     kotlin("jvm")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
 
-
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,4 +72,3 @@ fun RepositoryHandler.mavenNav(repo: String): MavenArtifactRepository {
 }
 
 fun printVersion() = println(version)
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.17"
+version = "0.0.18"
 
 plugins {
     kotlin("jvm")
@@ -66,4 +66,8 @@ fun RepositoryHandler.mavenNav(repo: String): MavenArtifactRepository {
             password = githubPassword
         }
     }
+}
+
+fun printVersionName() {
+    println (version)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
+version=0.0.18-SNAPSHOT
+
 kotlin.code.style=official
 
 # Plugin versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-version=0.0.18-SNAPSHOT
+version=0.0.18
+#Oops, "glemte" å bumpe snapshot! Testing testing
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-version=0.0.18
-#Oops, "glemte" å bumpe snapshot! Testing testing
+version=0.0.18-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/deprecated/JournalfoertInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/deprecated/JournalfoertInntektsmelding.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding.Type as Type
 
 @Deprecated("Bruk 'v1.JournalfoertInntektsmelding' istedenfor.")
 @Serializable
@@ -11,4 +12,5 @@ data class JournalfoertInntektsmelding(
     val journalpostId: String,
     @JsonNames("inntektsmeldingDokument") // TODO slett etter overgangsfase
     val inntektsmelding: Inntektsmelding,
+    val type: Type?, // for å skille på selvbestemt og vanlig i spinosaurus, før V1 tas i bruk overalt
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/deprecated/JournalfoertInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/deprecated/JournalfoertInntektsmelding.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonNames
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding.Type as Type
 
 @Deprecated("Bruk 'v1.JournalfoertInntektsmelding' istedenfor.")
 @Serializable
@@ -12,5 +11,5 @@ data class JournalfoertInntektsmelding(
     val journalpostId: String,
     @JsonNames("inntektsmeldingDokument") // TODO slett etter overgangsfase
     val inntektsmelding: Inntektsmelding,
-    val type: Type?, // for å skille på selvbestemt og vanlig i spinosaurus, før V1 tas i bruk overalt
+    val selvbestemt: Boolean = false, // for å skille på selvbestemt og vanlig i spinosaurus, før V1 tas i bruk overalt
 )


### PR DESCRIPTION
+ ny versjon-strategi, push til dev-branch publiserer snapshot-versjon for å gjøre det enklere for apper som tar i bruk avhengigheten mens det foregår utvikling. Skipper publiser dersom snapshot ikke er satt på branch, hadde kanskje vært bedre om publish-snapshot-workflow feilet da, men det blir i så fall neste iterasjon