### PR TITLE
Legg til skjema for forespurt inntektsmelding

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testImplementation(testFixtures("no.nav.helsearbeidsgiver:utils:$utilsVersion"))
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
     testImplementation("io.kotest:kotest-framework-datatest:$kotestVersion")
+    testImplementation("io.kotest:kotest-property:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
 }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/Utils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/Utils.kt
@@ -25,6 +25,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.RefusjonEndrin
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Sykefravaer
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.VarigLonnsendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
@@ -309,14 +310,14 @@ object Utils {
             is VarigLoennsendringV1 -> VarigLonnsendring(gjelderFra = this.gjelderFra)
         }
 
-    fun SkjemaInntektsmelding.convert(aarsakInnsending: AarsakInnsendingV1): Innsending {
+    fun SkjemaInntektsmelding.convert(sykmeldingsperioder: List<Periode>, aarsakInnsending: AarsakInnsendingV1): Innsending {
         val arbeidsgiverperioder = agp?.perioder.orEmpty()
         val egenmeldingsperioder = agp?.egenmeldinger.orEmpty()
 
         return Innsending(
-            identitetsnummer = sykmeldtFnr,
-            orgnrUnderenhet = avsender.orgnr,
-            telefonnummer = avsender.tlf,
+            identitetsnummer = "",
+            orgnrUnderenhet = "",
+            telefonnummer = avsenderTlf,
             behandlingsdager = emptyList(),
             arbeidsgiverperioder = arbeidsgiverperioder,
             egenmeldingsperioder = egenmeldingsperioder,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsgiverperiode.kt
@@ -9,6 +9,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.valider
 @Serializable
 data class Arbeidsgiverperiode(
     val perioder: List<Periode>,
+    // TODO vurder å fjerne om man heller kan utlede fra AGP og sykmeldingsperioder
     val egenmeldinger: List<Periode>,
     val redusertLoennIAgp: RedusertLoennIAgp?,
 ) {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaAvsender.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaAvsender.kt
@@ -9,16 +9,11 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 @Serializable
 data class SkjemaAvsender(
-    val orgnr: String,
+    val orgnr: Orgnr,
     val tlf: String,
 ) {
     internal fun valider(): List<FeiletValidering> =
         listOfNotNull(
-            valider(
-                vilkaar = Orgnr.erGyldig(orgnr),
-                feilmelding = Feilmelding.ORGNR,
-            ),
-
             valider(
                 vilkaar = tlf.erGyldigTlf(),
                 feilmelding = Feilmelding.TLF,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -7,14 +7,13 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.FeiletValidering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.erGyldigTlf
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.valider
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 
 @Serializable
 data class SkjemaInntektsmelding(
-    val sykmeldtFnr: String,
-    val avsender: SkjemaAvsender,
-    val sykmeldingsperioder: List<Periode>,
+    val avsenderTlf: String,
     val agp: Arbeidsgiverperiode?,
     val inntekt: Inntekt?,
     val refusjon: Refusjon?,
@@ -23,9 +22,32 @@ data class SkjemaInntektsmelding(
         listOfNotNull(
             listOfNotNull(
                 valider(
-                    vilkaar = Fnr.erGyldig(sykmeldtFnr),
-                    feilmelding = Feilmelding.FNR,
+                    vilkaar = avsenderTlf.erGyldigTlf(),
+                    feilmelding = Feilmelding.TLF,
                 ),
+            ),
+
+            agp?.valider(),
+            inntekt?.valider(),
+            refusjon?.valider(),
+
+            validerRefusjonMotInntekt(refusjon, inntekt),
+        )
+            .tilFeilmeldinger()
+}
+
+@Serializable
+data class SkjemaInntektsmeldingSelvbestemt(
+    val sykmeldtFnr: Fnr,
+    val avsender: SkjemaAvsender,
+    val sykmeldingsperioder: List<Periode>,
+    val agp: Arbeidsgiverperiode?,
+    val inntekt: Inntekt,
+    val refusjon: Refusjon?,
+) {
+    fun valider(): Set<String> =
+        listOfNotNull(
+            listOfNotNull(
                 valider(
                     vilkaar = sykmeldingsperioder.isNotEmpty(),
                     feilmelding = Feilmelding.SYKEMELDINGER_IKKE_TOM,
@@ -34,26 +56,32 @@ data class SkjemaInntektsmelding(
 
             avsender.valider(),
             agp?.valider(),
-            inntekt?.valider(),
+            inntekt.valider(),
             refusjon?.valider(),
 
-            if (inntekt != null && refusjon != null) {
-                listOfNotNull(
-                    valider(
-                        vilkaar = refusjon.beloepPerMaaned <= inntekt.beloep,
-                        feilmelding = Feilmelding.REFUSJON_OVER_INNTEKT,
-                    ),
-
-                    valider(
-                        vilkaar = refusjon.endringer.all { it.beloep <= inntekt.beloep },
-                        feilmelding = Feilmelding.REFUSJON_OVER_INNTEKT,
-                    ),
-                )
-            } else {
-                emptyList()
-            },
+            validerRefusjonMotInntekt(refusjon, inntekt),
         )
-            .flatten()
-            .map(FeiletValidering::feilmelding)
-            .toSet()
+            .tilFeilmeldinger()
 }
+
+private fun validerRefusjonMotInntekt(refusjon: Refusjon?, inntekt: Inntekt?): List<FeiletValidering> =
+    if (refusjon != null && inntekt != null) {
+        listOfNotNull(
+            valider(
+                vilkaar = refusjon.beloepPerMaaned <= inntekt.beloep,
+                feilmelding = Feilmelding.REFUSJON_OVER_INNTEKT,
+            ),
+
+            valider(
+                vilkaar = refusjon.endringer.all { it.beloep <= inntekt.beloep },
+                feilmelding = Feilmelding.REFUSJON_OVER_INNTEKT,
+            ),
+        )
+    } else {
+        emptyList()
+    }
+
+private fun List<List<FeiletValidering>>.tilFeilmeldinger(): Set<String> =
+    flatten()
+        .map(FeiletValidering::feilmelding)
+        .toSet()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -12,8 +12,6 @@ internal fun valider(vilkaar: Boolean, feilmelding: String): FeiletValidering? =
     }
 
 internal object Feilmelding {
-    const val ORGNR = "Ugyldig organisasjonsnummer"
-    const val FNR = "Ugyldig fødsels- eller D-nummer"
     const val TLF = "Ugyldig telefonnummer"
     const val SYKEMELDINGER_IKKE_TOM = "Sykmeldingsperioder må fylles ut"
     const val KREVER_BELOEP_STOERRE_ELLER_LIK_NULL = "Beløp må være større eller lik 0"

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/UtilsTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/UtilsTest.kt
@@ -38,7 +38,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.VarigLonnsendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.utils.test.date.februar
@@ -46,7 +45,6 @@ import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import no.nav.helsearbeidsgiver.utils.test.date.september
-import java.lang.IllegalArgumentException
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.util.UUID
@@ -276,7 +274,13 @@ class UtilsTest : FunSpec({
     context("konverter SkjemaInntektsmelding til Innsending") {
 
         test("fullt skjema") {
-            fulltSkjema().convert(AarsakInnsendingV1.Endring) shouldBe fullInnsending()
+
+            val innsending = fullInnsending().copy(
+                identitetsnummer = "",
+                orgnrUnderenhet = "",
+            )
+
+            fulltSkjema().convert(innsending.fraværsperioder, AarsakInnsendingV1.Endring) shouldBe innsending
         }
 
         test("fullt skjema uten redusert lønn i AGP") {
@@ -289,6 +293,8 @@ class UtilsTest : FunSpec({
             }
 
             val innsending = fullInnsending().copy(
+                identitetsnummer = "",
+                orgnrUnderenhet = "",
                 fullLønnIArbeidsgiverPerioden = FullLoennIArbeidsgiverPerioden(
                     utbetalerFullLønn = true,
                     begrunnelse = null,
@@ -296,7 +302,7 @@ class UtilsTest : FunSpec({
                 ),
             )
 
-            skjema.convert(AarsakInnsendingV1.Endring) shouldBe innsending
+            skjema.convert(innsending.fraværsperioder, AarsakInnsendingV1.Endring) shouldBe innsending
         }
 
         test("skjema uten agp") {
@@ -305,6 +311,8 @@ class UtilsTest : FunSpec({
             )
 
             val innsending = fullInnsending().copy(
+                identitetsnummer = "",
+                orgnrUnderenhet = "",
                 arbeidsgiverperioder = emptyList(),
                 egenmeldingsperioder = emptyList(),
                 fullLønnIArbeidsgiverPerioden = FullLoennIArbeidsgiverPerioden(
@@ -318,7 +326,7 @@ class UtilsTest : FunSpec({
                 ),
             )
 
-            skjema.convert(AarsakInnsendingV1.Endring) shouldBe innsending
+            skjema.convert(innsending.fraværsperioder, AarsakInnsendingV1.Endring) shouldBe innsending
         }
 
         test("skjema uten inntekt") {
@@ -327,6 +335,8 @@ class UtilsTest : FunSpec({
             )
 
             val innsending = fullInnsending().copy(
+                identitetsnummer = "",
+                orgnrUnderenhet = "",
                 inntekt = Inntekt(
                     bekreftet = true,
                     beregnetInntekt = -1.0,
@@ -341,7 +351,7 @@ class UtilsTest : FunSpec({
                 ),
             )
 
-            skjema.convert(AarsakInnsendingV1.Endring) shouldBe innsending
+            skjema.convert(innsending.fraværsperioder, AarsakInnsendingV1.Endring) shouldBe innsending
         }
 
         test("skjema uten refusjon") {
@@ -350,6 +360,8 @@ class UtilsTest : FunSpec({
             )
 
             val innsending = fullInnsending().copy(
+                identitetsnummer = "",
+                orgnrUnderenhet = "",
                 refusjon = Refusjon(
                     utbetalerHeleEllerDeler = false,
                     refusjonPrMnd = null,
@@ -362,7 +374,7 @@ class UtilsTest : FunSpec({
                 ),
             )
 
-            skjema.convert(AarsakInnsendingV1.Endring) shouldBe innsending
+            skjema.convert(innsending.fraværsperioder, AarsakInnsendingV1.Endring) shouldBe innsending
         }
     }
 })
@@ -432,15 +444,7 @@ private fun lagGammelInntektsmelding(): Inntektsmelding =
 
 private fun fulltSkjema(): SkjemaInntektsmelding =
     SkjemaInntektsmelding(
-        sykmeldtFnr = "03042400123",
-        avsender = SkjemaAvsender(
-            orgnr = "454989232",
-            tlf = "47475555",
-        ),
-        sykmeldingsperioder = listOf(
-            4.januar til 24.februar,
-            3.mars til 22.mars,
-        ),
+        avsenderTlf = "47475555",
         agp = Arbeidsgiverperiode(
             perioder = listOf(
                 2.januar til 17.januar,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/PeriodeTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/PeriodeTest.kt
@@ -1,0 +1,47 @@
+package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
+
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+import java.time.LocalDate
+
+class PeriodeTest : FunSpec({
+
+    val testFns = mapOf(
+        "constructor" to ::Periode,
+        "til" to { fom, tom -> fom til tom },
+    )
+
+    context("gyldig periode") {
+        withData(testFns) { lagPeriodeFn ->
+            checkAll<LocalDate, LocalDate> { a, b ->
+                val datoer = listOf(a, b).sorted()
+
+                val fom = datoer.first()
+                val tom = datoer.last()
+
+                val periode = lagPeriodeFn(fom, tom)
+
+                periode.fom shouldBe fom
+                periode.tom shouldBe tom
+            }
+        }
+    }
+
+    context("ugyldig periode") {
+        withData(testFns) { lagPeriodeFn ->
+            checkAll<LocalDate, LocalDate> { a, b ->
+                val datoer = listOf(a, b).sorted()
+
+                val fom = datoer.first()
+                val tom = datoer.last()
+
+                shouldThrowExactly<IllegalArgumentException> {
+                    lagPeriodeFn(tom, fom)
+                }
+            }
+        }
+    }
+})


### PR DESCRIPTION
Det eksisterende skjema får en `-Selvbestemt`-postfix på klassenavnet, og klassen for forespurt IM overtar navnet `SkjemaInntektsmelding`. 

Det nye skjemaet ligner veldig på det gamle. Hovedforskjellene er at det ikke har fnr på sykmeldt, orgnr og sykmeldingsperioder (som vi heller henter fra forespørsel) og at inntekt er valgfritt (forespørsel inneholder da et forslag).