### PR TITLE
Sett defaultverdi for vedtaksperiodeId for å være bakoverkopatibel i frontend

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.5-SNAPSHOT
+version=0.1.5
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.4
+version=0.1.5-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -55,7 +55,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val agp: Arbeidsgiverperiode?,
     val inntekt: Inntekt,
     val refusjon: Refusjon?,
-    val vedtaksperiodeId: UUID?, // TODO: Skal ikke være nullable - Endre når frontend har implementert og er i produksjon
+    val vedtaksperiodeId: UUID? = null, // TODO: Skal ikke være nullable - Endre når frontend har implementert og er i produksjon
 ) {
     fun valider(): Set<String> =
         listOfNotNull(


### PR DESCRIPTION
Innsending av arbeidsgiverinitierte IMer brakk fordi vedtaksperiodeId ikke ennå kommer fra frontend, og backend ikke satt noen defaultverdi.