### PR TITLE
validering av datoer for refusjonEndring

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.1.8
+version=0.1.9-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -40,6 +40,7 @@ data class SkjemaInntektsmelding(
             inntekt?.valider(),
             refusjon?.valider(),
             validerRefusjonMotInntekt(refusjon, inntekt),
+            validerRefusjonMotAgp(refusjon, agp),
         ).tilFeilmeldinger()
 }
 
@@ -68,6 +69,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
             refusjon?.valider(),
             validerBestemmendeFravaersdagMotInntektsdato(agp, inntekt, sykmeldingsperioder),
             validerRefusjonMotInntekt(refusjon, inntekt),
+            validerRefusjonMotAgp(refusjon, agp),
         ).tilFeilmeldinger()
 }
 
@@ -113,10 +115,36 @@ private fun validerRefusjonMotInntekt(
                 vilkaar = refusjon.endringer.all { it.beloep <= inntekt.beloep },
                 feilmelding = Feilmelding.REFUSJON_OVER_INNTEKT,
             ),
+            // "Fallback"-sjekk dersom ingen AGP - da skal dato for refusjonEndring alltid være senere enn InntektDato
+            valider(
+                vilkaar = refusjon.endringer.all { it.startdato.isAfter(inntekt.inntektsdato) },
+                feilmelding = Feilmelding.REFUSJON_ENDRING_FOER_INNTEKTDATO,
+            ),
+
         )
     } else {
         emptyList()
     }
+
+/*
+Endring i refusjon skal alltid ha dato etter AGP (dersom det er AGP).
+ */
+private fun validerRefusjonMotAgp(refusjon: Refusjon?, agp: Arbeidsgiverperiode?): List<FeiletValidering> {
+    val agpMax = agp?.let {
+            arbeidsgiverperiode ->
+        arbeidsgiverperiode.perioder.maxOfOrNull { it.tom }
+    }
+    if (agpMax == null) {
+        return emptyList()
+    } else {
+        return refusjon?.endringer?.mapNotNull { endring ->
+            valider(
+                vilkaar = endring.startdato.isAfter(agpMax),
+                feilmelding = Feilmelding.REFUSJON_ENDRING_FOER_AGP_SLUTT,
+            )
+        }.orEmpty()
+    }
+}
 
 private fun List<List<FeiletValidering>>.tilFeilmeldinger(): Set<String> =
     flatten()

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -20,6 +20,8 @@ internal object Feilmelding {
     const val AGP_MAKS_16 = "Arbeidsgiverperioden kan være maksimum 16 dager"
     const val REFUSJON_OVER_INNTEKT = "Refusjonsbeløp må være mindre eller lik inntekt"
     const val REFUSJON_ENDRING_DATO = "Refusjonsendringer må være før eller lik siste dato for refusjon"
+    const val REFUSJON_ENDRING_FOER_AGP_SLUTT = "Startdato for refusjonsendringer må være etter arbeidsgiverperiode"
+    const val REFUSJON_ENDRING_FOER_INNTEKTDATO = "Startdato for refusjonsendringer må være etter inntektdato"
 
     // Feil i koden, ingenting bruker kan gjøre
     const val TEKNISK_FEIL = "Det oppsto en feil i systemet. Prøv igjen senere."


### PR DESCRIPTION
Endringer i refusjon skal alltid legges inn med dato etter Arbeidsgiverperiode. 
Dersom ingen AGP (ved forlenging / forenklet IM), bruker vi inntektdato som en "best effort"