### PR TITLE
Bump avhengigheter

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,14 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
-          cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build and test
         run: ./gradlew build test

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,25 +7,25 @@ on:
 
 jobs:
   publish-snapshot:
-    env:
-      ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
     runs-on: ubuntu-latest
     permissions:
       packages: write
+    env:
+      ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
-          cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v4
+
       - name: Get Version
         run:  |
           echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)"
           echo "CURRENT_VERSION=$(./gradlew :printVersion --quiet)" >> $GITHUB_ENV
+
       - name: Publish artifact
         if: ${{ endsWith(env.CURRENT_VERSION, '-SNAPSHOT') }}
         run: ./gradlew publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,14 +14,12 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
-          cache: gradle
 
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Publish artifact
         run: ./gradlew publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_17)
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ version=0.2.1
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=1.9.10
+kotlinVersion=2.0.20
 kotlinterVersion=3.16.0
 
 # Dependency versions
-kotestVersion=5.7.2
-kotlinxSerializationVersion=1.6.0
+kotestVersion=5.9.1
+kotlinxSerializationVersion=1.8.0
 utilsVersion=0.9.0

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/PeriodeTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/PeriodeTest.kt
@@ -9,7 +9,8 @@ import java.time.LocalDate
 
 class PeriodeTest : FunSpec({
 
-    val testFns = mapOf(
+    // kompilatoren tryner uten typeargumenter, selv om den påstår at de er unødvendige her
+    val testFns = mapOf<String, (LocalDate, LocalDate) -> Periode>(
         "constructor" to ::Periode,
         "til" to { fom, tom -> fom til tom },
     )


### PR DESCRIPTION
`gradle/gradle-build-action@v3` ble erstattet med `gradle/actions/setup-gradle@v3`. Se https://github.com/gradle/gradle-build-action/releases/tag/v3.0.0.

I tillegg ble caching endret i `setup-gradle@v4`. Det medfører at caching via `actions/cache` og/eller `with.cache: gradle` fra `actions/setup-java` fjernes, som beskrevet [her](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms).