### PR TITLE
aarsakEndring -> aarsakEndringer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.0
+version=0.3.1-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.1-SNAPSHOT
+version=0.3.1
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntekt.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntekt.kt
@@ -17,7 +17,7 @@ data class Inntekt(
     val beloep: Double,
     val inntektsdato: LocalDate,
     val naturalytelser: List<Naturalytelse>,
-    val endringAarsaker: List<InntektEndringAarsak>? = null,
+    val endringAarsaker: List<InntektEndringAarsak>,
 ) {
     internal fun valider(): List<FeiletValidering> =
         listOfNotNull(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntekt.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntekt.kt
@@ -17,7 +17,6 @@ data class Inntekt(
     val beloep: Double,
     val inntektsdato: LocalDate,
     val naturalytelser: List<Naturalytelse>,
-    val endringAarsak: InntektEndringAarsak?,
     val endringAarsaker: List<InntektEndringAarsak>? = null,
 ) {
     internal fun valider(): List<FeiletValidering> =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -47,11 +47,6 @@ class TestData {
                                     sluttdato = 25.juni,
                                 ),
                             ),
-                        endringAarsak =
-                            Tariffendring(
-                                gjelderFra = 30.juni,
-                                bleKjent = 5.juli,
-                            ),
                         endringAarsaker =
                             listOf(
                                 Tariffendring(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -296,13 +296,13 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                     }
                 }
 
-                test("'endringAarsaker' kan være 'null'") {
+                test("'endringAarsaker' kan være tom") {
                     val skjema =
                         fulltSkjema().let {
                             it.copy(
                                 inntekt =
                                     it.inntekt.copy(
-                                        endringAarsaker = null,
+                                        endringAarsaker = emptyList(),
                                     ),
                             )
                         }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -296,13 +296,13 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                     }
                 }
 
-                test("'endringAarsak' kan være 'null'") {
+                test("'endringAarsaker' kan være 'null'") {
                     val skjema =
                         fulltSkjema().let {
                             it.copy(
                                 inntekt =
                                     it.inntekt.copy(
-                                        endringAarsak = null,
+                                        endringAarsaker = null,
                                     ),
                             )
                         }
@@ -565,11 +565,6 @@ private fun fulltSkjema(): SkjemaInntektsmeldingSelvbestemt =
                             verdiBeloep = 555.0,
                             sluttdato = 25.juni,
                         ),
-                    ),
-                endringAarsak =
-                    Tariffendring(
-                        gjelderFra = 30.juni,
-                        bleKjent = 5.juli,
                     ),
                 endringAarsaker =
                     listOf(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -218,13 +218,13 @@ class SkjemaInntektsmeldingTest :
                     }
                 }
 
-                test("'endringAarsak' kan være 'null'") {
+                test("'endringAarsaker' kan være 'null'") {
                     val skjema =
                         TestData.fulltSkjema().let {
                             it.copy(
                                 inntekt =
                                     it.inntekt?.copy(
-                                        endringAarsak = null,
+                                        endringAarsaker = null,
                                     ),
                             )
                         }
@@ -334,7 +334,6 @@ class SkjemaInntektsmeldingTest :
                             beloep = 51000.0,
                             inntektsdato = inntektDato,
                             naturalytelser = emptyList(),
-                            endringAarsak = null,
                             endringAarsaker = null,
                         )
                     val ugyldigRefusjon =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -218,13 +218,13 @@ class SkjemaInntektsmeldingTest :
                     }
                 }
 
-                test("'endringAarsaker' kan være 'null'") {
+                test("'endringAarsaker' kan være tom") {
                     val skjema =
                         TestData.fulltSkjema().let {
                             it.copy(
                                 inntekt =
                                     it.inntekt?.copy(
-                                        endringAarsaker = null,
+                                        endringAarsaker = emptyList(),
                                     ),
                             )
                         }
@@ -334,7 +334,7 @@ class SkjemaInntektsmeldingTest :
                             beloep = 51000.0,
                             inntektsdato = inntektDato,
                             naturalytelser = emptyList(),
-                            endringAarsaker = null,
+                            endringAarsaker = emptyList(),
                         )
                     val ugyldigRefusjon =
                         Refusjon(


### PR DESCRIPTION
Fjerner gammelt felt aarsakEndring, 
det er erstattet av liste aarsakEndringer.

Data i db er migrert, slik at historiske verdier av skjema har aarsakEndring blitt lagt til i aarsakEndringer.
Der det ikke var noe, er det lagt til en tom liste. 

Endrer derfor også fra nullable til å kreve at listen aarsakEndringer alltid blir satt. 