### PR TITLE
Fjerner refusjon.sluttdato

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.2-SNAPSHOT
+version=0.3.2
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.1
+version=0.3.2-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Refusjon.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Refusjon.kt
@@ -15,7 +15,6 @@ import java.time.LocalDate
 data class Refusjon(
     val beloepPerMaaned: Double,
     val endringer: List<RefusjonEndring>,
-    val sluttdato: LocalDate?,
 ) {
     internal fun valider(): List<FeiletValidering> =
         listOfNotNull(
@@ -26,10 +25,6 @@ data class Refusjon(
             valider(
                 vilkaar = endringer.all(RefusjonEndring::erGyldig),
                 feilmelding = Feilmelding.KREVER_BELOEP_STOERRE_ELLER_LIK_NULL,
-            ),
-            valider(
-                vilkaar = sluttdato == null || endringer.map(RefusjonEndring::startdato).all { !it.isAfter(sluttdato) },
-                feilmelding = Feilmelding.REFUSJON_ENDRING_DATO,
             ),
         )
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -22,7 +22,6 @@ internal object Feilmelding {
     const val AGP_IKKE_TOM = "Arbeidsgiverperioden må fylles ut, med mindre man betaler redusert lønn i perioden"
     const val AGP_MAKS_16 = "Arbeidsgiverperioden kan være maksimum 16 dager"
     const val REFUSJON_OVER_INNTEKT = "Refusjonsbeløp må være mindre eller lik inntekt"
-    const val REFUSJON_ENDRING_DATO = "Refusjonsendringer må være før eller lik siste dato for refusjon"
     const val REFUSJON_ENDRING_FOER_AGP_SLUTT = "Startdato for refusjonsendringer må være etter arbeidsgiverperiode"
     const val REFUSJON_ENDRING_FOER_INNTEKTDATO = "Startdato for refusjonsendringer må være etter inntektdato"
     const val DUPLIKAT_INNTEKT_ENDRINGSAARSAK = "Endringsårsaker kan ikke inneholde duplikater"

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -69,7 +69,6 @@ class TestData {
                                     startdato = 20.juli,
                                 ),
                             ),
-                        sluttdato = null,
                     ),
             )
     }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -369,41 +369,6 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                         skjema.valider() shouldContainAll forventetFeil
                     }
                 }
-
-                test("'sluttdato' kan være 'null'") {
-                    val skjema =
-                        fulltSkjema().let {
-                            it.copy(
-                                refusjon =
-                                    it.refusjon?.copy(
-                                        sluttdato = null,
-                                    ),
-                            )
-                        }
-
-                    skjema.valider().shouldBeEmpty()
-                }
-
-                test("ugyldig dato i endring (må være før eller lik (non-null) 'sluttdato')") {
-                    val skjema =
-                        fulltSkjema().let {
-                            it.copy(
-                                refusjon =
-                                    it.refusjon?.copy(
-                                        endringer =
-                                            listOf(
-                                                RefusjonEndring(
-                                                    beloep = 4567.0,
-                                                    startdato = 4.august,
-                                                ),
-                                            ),
-                                        sluttdato = 1.august,
-                                    ),
-                            )
-                        }
-
-                    skjema.valider() shouldBe setOf(Feilmelding.REFUSJON_ENDRING_DATO)
-                }
             }
 
             test("bestemmende fraværsdag før inntektsdato") {
@@ -587,8 +552,11 @@ private fun fulltSkjema(): SkjemaInntektsmeldingSelvbestemt =
                             beloep = 6000.0,
                             startdato = 20.juli,
                         ),
+                        RefusjonEndring(
+                            beloep = 0.0,
+                            startdato = 30.juli,
+                        ),
                     ),
-                sluttdato = null,
             ),
         vedtaksperiodeId = UUID.randomUUID(),
     )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -292,20 +292,6 @@ class SkjemaInntektsmeldingTest :
                     }
                 }
 
-                test("'sluttdato' kan være 'null'") {
-                    val skjema =
-                        TestData.fulltSkjema().let {
-                            it.copy(
-                                refusjon =
-                                    it.refusjon?.copy(
-                                        sluttdato = null,
-                                    ),
-                            )
-                        }
-
-                    skjema.valider().shouldBeEmpty()
-                }
-
                 test("dato for refusjonEndring må være etter AGP") {
                     val agpFom = 4.juni
                     val agpTom = 18.juni
@@ -315,7 +301,6 @@ class SkjemaInntektsmeldingTest :
                         Refusjon(
                             beloepPerMaaned = 50000.0,
                             endringer = listOf(RefusjonEndring(beloep = 10.0, startdato = agpTom)),
-                            sluttdato = null,
                         )
                     val skjema =
                         TestData.fulltSkjema().copy(
@@ -340,7 +325,6 @@ class SkjemaInntektsmeldingTest :
                         Refusjon(
                             beloepPerMaaned = 50000.0,
                             endringer = listOf(RefusjonEndring(beloep = 10.0, startdato = inntektDato.minusDays(1))),
-                            sluttdato = null,
                         )
                     val skjema =
                         TestData.fulltSkjema().copy(
@@ -350,27 +334,6 @@ class SkjemaInntektsmeldingTest :
                         )
 
                     skjema.valider() shouldBe setOf(Feilmelding.REFUSJON_ENDRING_FOER_INNTEKTDATO)
-                }
-
-                test("ugyldig dato i endring (må være før eller lik (non-null) 'sluttdato')") {
-                    val skjema =
-                        TestData.fulltSkjema().let {
-                            it.copy(
-                                refusjon =
-                                    it.refusjon?.copy(
-                                        endringer =
-                                            listOf(
-                                                RefusjonEndring(
-                                                    beloep = 4567.0,
-                                                    startdato = 4.august,
-                                                ),
-                                            ),
-                                        sluttdato = 1.august,
-                                    ),
-                            )
-                        }
-
-                    skjema.valider() shouldBe setOf(Feilmelding.REFUSJON_ENDRING_DATO)
                 }
             }
 


### PR DESCRIPTION
Dette feltet er erstattet ved at bruker legger inn en endring med beløp 0 og en startDato.
Når denne versjonen av domene tas i bruk, vil vi ikke lese sluttdato-feltet fra payload i databasen 
(frontend støtter allerede at dette feltet ikke kommer / er null) 
Før denne versjonen tas i bruk i simba, skal payloads i databasen konverteres slik at sluttdato-feltet nulles og konverteres til endring der dette ikke er satt allerede. Se sql-script i https://trello.com/c/KdzsCQYi

For sykepenger-lps-api har vi kun nye payloads uten sluttdato, så her kan denne versjonen brukes umiddelbart uten database-konvertering
