### PR TITLE
Fjern altinn kanal

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.2
+version=0.3.3
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -73,5 +73,4 @@ data class Inntektsmelding(
 enum class Kanal {
     NAV_NO,
     HR_SYSTEM_API,
-    ALTINN,
 }


### PR DESCRIPTION
Fjerner altinn kanal fordi det ikke skal være mulig å sende inn inntetsmelding fra altinn i simba.
