### PR TITLE
Legger til Fisker og UtenArbeidsforhold som typer i inntektsmelding

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.3
+version=0.3.4-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.4-SNAPSHOT
+version=0.3.4
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -26,9 +26,7 @@ data class Inntektsmelding(
     val refusjon: Refusjon?,
     val aarsakInnsending: AarsakInnsending,
     val mottatt: OffsetDateTime,
-    val vedtaksperiodeId: UUID? = null,
-    // TODO: vedtaksperiodeID skal ikke være nullable
-    // - men må vente til alle gamle saker / selvbestemtIMer har blitt slettet - ETA November 2025
+    val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
 ) {
     @Serializable
     sealed class Type {
@@ -39,7 +37,7 @@ data class Inntektsmelding(
         fun kanal(): Kanal =
             when (this) {
                 is ForespurtEkstern -> Kanal.HR_SYSTEM_API
-                is Forespurt, is Selvbestemt -> Kanal.NAV_NO
+                is Forespurt, is Selvbestemt, is Fisker, is UtenArbeidsforhold -> Kanal.NAV_NO
             }
 
         @Serializable
@@ -54,6 +52,24 @@ data class Inntektsmelding(
         @Serializable
         @SerialName("Selvbestemt")
         data class Selvbestemt(
+            override val id: UUID,
+        ) : Type() {
+            @EncodeDefault
+            override val avsenderSystem: AvsenderSystem = AvsenderSystem()
+        }
+
+        @Serializable
+        @SerialName("Fisker")
+        data class Fisker(
+            override val id: UUID,
+        ) : Type() {
+            @EncodeDefault
+            override val avsenderSystem: AvsenderSystem = AvsenderSystem()
+        }
+
+        @Serializable
+        @SerialName("UtenArbeidsforhold")
+        data class UtenArbeidsforhold(
             override val id: UUID,
         ) : Type() {
             @EncodeDefault

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -53,7 +53,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val agp: Arbeidsgiverperiode?,
     val inntekt: Inntekt,
     val refusjon: Refusjon?,
-    val vedtaksperiodeId: UUID? = null, // TODO: Skal ikke være nullable - Endre når frontend har implementert og er i produksjon
+    val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
 ) {
     fun valider(): Set<String> =
         listOfNotNull(


### PR DESCRIPTION
Del av større oppdrag med å skru av Altinn skjema som krever all funksjonalitet i den til å støttes på nav.no

Denne endringen skiller de med og uten arbeidsforhold i selvbestemte inntektsmeldinger.

En spesiell type for fiskere er lagt til for bedre statistisk analyse og fremtidlig støtte av ny funksjonalitet