### PR TITLE
Utvider selvbestemt Skjema med nytt felt arbeidsforholdType

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.3
+version=0.3.4-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=0.3.4
+version=0.3.5-SNAPSHOT
 
 kotlin.code.style=official
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -26,9 +26,7 @@ data class Inntektsmelding(
     val refusjon: Refusjon?,
     val aarsakInnsending: AarsakInnsending,
     val mottatt: OffsetDateTime,
-    val vedtaksperiodeId: UUID? = null,
-    // TODO: vedtaksperiodeID skal ikke være nullable
-    // - men må vente til alle gamle saker / selvbestemtIMer har blitt slettet - ETA November 2025
+    val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
 ) {
     @Serializable
     sealed class Type {
@@ -39,7 +37,7 @@ data class Inntektsmelding(
         fun kanal(): Kanal =
             when (this) {
                 is ForespurtEkstern -> Kanal.HR_SYSTEM_API
-                is Forespurt, is Selvbestemt -> Kanal.NAV_NO
+                is Forespurt, is Selvbestemt, is Fisker, is UtenArbeidsforhold -> Kanal.NAV_NO
             }
 
         @Serializable
@@ -54,6 +52,24 @@ data class Inntektsmelding(
         @Serializable
         @SerialName("Selvbestemt")
         data class Selvbestemt(
+            override val id: UUID,
+        ) : Type() {
+            @EncodeDefault
+            override val avsenderSystem: AvsenderSystem = AvsenderSystem()
+        }
+
+        @Serializable
+        @SerialName("Fisker")
+        data class Fisker(
+            override val id: UUID,
+        ) : Type() {
+            @EncodeDefault
+            override val avsenderSystem: AvsenderSystem = AvsenderSystem()
+        }
+
+        @Serializable
+        @SerialName("UtenArbeidsforhold")
+        data class UtenArbeidsforhold(
             override val id: UUID,
         ) : Type() {
             @EncodeDefault

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/ArbeidsforholdType.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/ArbeidsforholdType.kt
@@ -1,0 +1,26 @@
+@file:UseSerializers(UuidSerializer::class)
+
+package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import java.util.UUID
+
+@Serializable
+sealed class ArbeidsforholdType {
+    @Serializable
+    @SerialName("MedArbeidsforhold")
+    data class MedArbeidsforhold(
+        val vedtaksperiodeId: UUID,
+    ) : ArbeidsforholdType()
+
+    @Serializable
+    @SerialName("Fisker")
+    object Fisker : ArbeidsforholdType()
+
+    @Serializable
+    @SerialName("UtenArbeidsforhold")
+    object UtenArbeidsforhold : ArbeidsforholdType()
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -2,6 +2,8 @@
 
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
@@ -44,6 +46,7 @@ data class SkjemaInntektsmelding(
         ).tilFeilmeldinger()
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SkjemaInntektsmeldingSelvbestemt(
     val selvbestemtId: UUID?,
@@ -54,6 +57,8 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val inntekt: Inntekt,
     val refusjon: Refusjon?,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
+    @EncodeDefault
+    val arbeidsforholdType: ArbeidsforholdType,
 ) {
     fun valider(): Set<String> =
         listOfNotNull(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -53,7 +53,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val agp: Arbeidsgiverperiode?,
     val inntekt: Inntekt,
     val refusjon: Refusjon?,
-    val vedtaksperiodeId: UUID? = null, // TODO: Skal ikke være nullable - Endre når frontend har implementert og er i produksjon
+    val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
 ) {
     fun valider(): Set<String> =
         listOfNotNull(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -479,9 +479,26 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                     )
             }
         }
+
+        test("serialiserer og deserialiserer arbeidsforholdType") {
+
+            val vedtaksperiodeId = UUID.randomUUID()
+            val skjema = fulltSkjema(vedtaksperiodeId = vedtaksperiodeId)
+
+            skjema.arbeidsforholdType shouldBe ArbeidsforholdType.MedArbeidsforhold(vedtaksperiodeId)
+
+            val json = skjema.toJson(SkjemaInntektsmeldingSelvbestemt.serializer())
+            val deserialisertSkjema =
+                json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
+
+            deserialisertSkjema.arbeidsforholdType shouldBe
+                ArbeidsforholdType.MedArbeidsforhold(
+                    vedtaksperiodeId,
+                )
+        }
     })
 
-private fun fulltSkjema(): SkjemaInntektsmeldingSelvbestemt =
+private fun fulltSkjema(vedtaksperiodeId: UUID = UUID.randomUUID()): SkjemaInntektsmeldingSelvbestemt =
     SkjemaInntektsmeldingSelvbestemt(
         selvbestemtId = UUID.randomUUID(),
         sykmeldtFnr = Fnr("11037400132"),
@@ -558,5 +575,6 @@ private fun fulltSkjema(): SkjemaInntektsmeldingSelvbestemt =
                         ),
                     ),
             ),
-        vedtaksperiodeId = UUID.randomUUID(),
+        vedtaksperiodeId = vedtaksperiodeId,
+        arbeidsforholdType = ArbeidsforholdType.MedArbeidsforhold(vedtaksperiodeId),
     )


### PR DESCRIPTION
For å støtte flere varianter i selvbestemt flyten har vi lagt til et nytt felt `arbeidsforholdType` med tre varianter `MedArbeidsforhold`, `UtenArbeidsforhold` og `Fisker`
Vi flytter også vedtaksperiode inn i MedArbeidsforhold typen slik at det ikke blir nullable lenger