### PR TITLE
Fiks validering for AGP over 16 dager

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/BestemmendeFravaersdag.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/BestemmendeFravaersdag.kt
@@ -1,7 +1,7 @@
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
 
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.agpPaavirkerIkkeInntektsmelding
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.daysUntil
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.antallDager
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.slaaSammenSammenhengendePerioder
 import java.time.LocalDate
 
@@ -65,7 +65,7 @@ private fun List<Periode>.fjernPerioderEtterFoersteUtoverAgp(): List<Periode> =
         val antallForegaaendeDager =
             slice(0..<index)
                 .sumOf {
-                    it.fom.daysUntil(it.tom) + 1
+                    it.antallDager()
                 }
 
         antallForegaaendeDager <= AGP_MAKS_DAGER

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -19,10 +19,9 @@ internal object Feilmelding {
     const val SYKEMELDINGER_IKKE_TOM = "Sykmeldingsperioder må fylles ut"
     const val KREVER_BELOEP_STOERRE_ELLER_LIK_NULL = "Beløp må være større eller lik 0"
     const val KREVER_BELOEP_STOERRE_ENN_NULL = "Beløp må være større enn 0"
-    const val AGP_IKKE_TOM = "Arbeidsgiverperioden må fylles ut, med mindre man betaler redusert lønn i perioden"
     const val AGP_MAKS_16 = "Arbeidsgiverperioden kan være maksimum 16 dager"
-    const val AGP_UNDER_16_OG_IKKE_GYLDIGE_BEHANDLINGSDAGER =
-        "Arbeidsgiverperioden må være 16 dager om det ikke er en begrunnelse eller behandlingsdager"
+    const val AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER =
+        "Arbeidsgiverperioden må være 16 dager, med mindre man betaler redusert lønn i perioden eller det gjelder behandlingsdager"
     const val REFUSJON_OVER_INNTEKT = "Refusjonsbeløp må være mindre eller lik inntekt"
     const val REFUSJON_ENDRING_FOER_AGP_SLUTT = "Startdato for refusjonsendringer må være etter arbeidsgiverperiode"
     const val REFUSJON_ENDRING_FOER_INNTEKTDATO = "Startdato for refusjonsendringer må være etter inntektdato"

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/PeriodeUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/PeriodeUtils.kt
@@ -28,7 +28,7 @@ fun utledEgenmeldinger(
 
 internal fun LocalDate.daysUntil(other: LocalDate): Int = until(other, ChronoUnit.DAYS).toInt()
 
-internal fun List<Periode>.sumAntallDager(): Int = sumOf { it.fom.daysUntil(it.tom) + 1 }
+internal fun Periode.antallDager(): Int = fom.daysUntil(tom) + 1
 
 internal fun agpPaavirkerIkkeInntektsmelding(
     agpSlutt: LocalDate,
@@ -61,11 +61,9 @@ internal fun List<Periode>.slaaSammenSammenhengendePerioder(ignorerHelgegap: Boo
         }
 }
 
-fun List<Periode>.tilDatoer(): Set<LocalDate> =
+internal fun List<Periode>.tilDatoer(): Set<LocalDate> =
     flatMap {
-        val antallDager = it.fom.daysUntil(it.tom) + 1
-
-        List(antallDager) { index ->
+        List(it.antallDager()) { index ->
             it.fom.plusDays(index.toLong())
         }
     }.toSet()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -145,7 +145,7 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                             )
                         }
 
-                    skjema.valider() shouldBe setOf(Feilmelding.AGP_IKKE_TOM)
+                    skjema.valider() shouldBe setOf(Feilmelding.AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER)
                 }
 
                 test("AGP kan være tom når AG _ikke_ betaler full lønn i AGP") {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -63,7 +63,7 @@ class SkjemaInntektsmeldingTest :
                             )
                         }
 
-                    skjema.valider() shouldBe setOf(Feilmelding.AGP_IKKE_TOM)
+                    skjema.valider() shouldBe setOf(Feilmelding.AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER)
                 }
 
                 test("AGP kan _ikke_ være 1 dag når AG betaler full lønn i AGP") {
@@ -78,7 +78,7 @@ class SkjemaInntektsmeldingTest :
                             )
                         }
 
-                    skjema.valider() shouldBe setOf(Feilmelding.AGP_UNDER_16_OG_IKKE_GYLDIGE_BEHANDLINGSDAGER)
+                    skjema.valider() shouldBe setOf(Feilmelding.AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER)
                 }
 
                 test("AGP kan være tom når AG _ikke_ betaler full lønn i AGP") {
@@ -130,7 +130,9 @@ class SkjemaInntektsmeldingTest :
                                                 8.august til 17.august,
                                                 20.august til 31.august,
                                             ),
+                                        redusertLoennIAgp = null,
                                     ),
+                                // Hindrer kryssvalidering mot refusjon, som vi ikke tester her
                                 refusjon = null,
                             )
                         }
@@ -162,14 +164,14 @@ class SkjemaInntektsmeldingTest :
                     test("kan ikke inneholde flere perioder i samme uke") {
                         val flereGangerIUken = behandlingsdager.take(11).plus(Periode(2.januar, 2.januar))
                         flereGangerIUken.tilArbeidsgiverperiode().valider() shouldBe
-                            listOf(FeiletValidering(Feilmelding.AGP_UNDER_16_OG_IKKE_GYLDIGE_BEHANDLINGSDAGER))
+                            listOf(FeiletValidering(Feilmelding.AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER))
                     }
                     test("kan ikke inneholde flere perioder i samme uke selv over et årsskifte") {
                         val peiode2024 = Periode(31.desember(2024), 31.desember(2024))
                         val periode2025 = Periode(1.januar(2025), 1.januar(2025))
                         val overAarSkifte = behandlingsdager.take(10).plus(peiode2024).plus(periode2025)
                         overAarSkifte.tilArbeidsgiverperiode().valider() shouldBe
-                            listOf(FeiletValidering(Feilmelding.AGP_UNDER_16_OG_IKKE_GYLDIGE_BEHANDLINGSDAGER))
+                            listOf(FeiletValidering(Feilmelding.AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER))
                     }
                 }
 
@@ -472,7 +474,7 @@ class SkjemaInntektsmeldingTest :
                             agp =
                                 it.agp?.copy(
                                     redusertLoennIAgp =
-                                        it.agp?.redusertLoennIAgp?.copy(
+                                        it.agp.redusertLoennIAgp?.copy(
                                             beloep = -11.0,
                                         ),
                                 ),


### PR DESCRIPTION
Oppdaget en feil i valideringen når AGP var over 16 dager som resulterte to feilmeldinger: en for over 16 dager, og en for under 16 dager. Det ble ikke plukket opp av testene fordi testen for over 16 dager var satt opp feil. Fikser dette, og slår sammen feilmeldingene for tom AGP og AGP under 16 dager, siden de egentlig dekkes av samme kriterier.