### PR TITLE
Bump avhengigheter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ group = "no.nav.helsearbeidsgiver"
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
+    id("io.kotest")
     id("org.jmailen.kotlinter")
     id("maven-publish")
 }
@@ -19,10 +20,10 @@ tasks {
     test {
         useJUnitPlatform()
     }
-}
 
-tasks.register("printVersion") {
-    printVersion()
+    register("printVersion") {
+        printVersion()
+    }
 }
 
 java {
@@ -55,7 +56,7 @@ dependencies {
 
     testImplementation(testFixtures("no.nav.helsearbeidsgiver:utils:$utilsVersion"))
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
-    testImplementation("io.kotest:kotest-framework-datatest:$kotestVersion")
+    testImplementation("io.kotest:kotest-framework-engine:$kotestVersion")
     testImplementation("io.kotest:kotest-property:$kotestVersion")
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ version=0.3.7
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=2.0.20
-kotlinterVersion=5.0.1
+kotlinVersion=2.2.20
+kotlinterVersion=5.2.0
 
 # Dependency versions
-kotestVersion=5.9.1
-kotlinxSerializationVersion=1.8.0
-utilsVersion=0.9.0
+kotestVersion=6.0.3
+kotlinxSerializationVersion=1.9.0
+utilsVersion=0.10.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,10 +3,12 @@ rootProject.name = "domene-inntektsmelding"
 pluginManagement {
     plugins {
         val kotlinVersion: String by settings
+        val kotestVersion: String by settings
         val kotlinterVersion: String by settings
 
         kotlin("jvm") version kotlinVersion
         kotlin("plugin.serialization") version kotlinVersion
+        id("io.kotest") version kotestVersion
         id("org.jmailen.kotlinter") version kotlinterVersion
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -1,7 +1,7 @@
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.core.spec.style.scopes.ContainerScope
+import io.kotest.core.spec.style.scopes.FunSpecContainerScope
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
@@ -521,7 +521,7 @@ class SkjemaInntektsmeldingTest :
         }
     })
 
-internal suspend fun ContainerScope.testBeloep(testFn: (Double, Set<String>) -> Unit) {
+internal suspend fun FunSpecContainerScope.testBeloep(testFn: (Double, Set<String>) -> Unit) {
     withData(
         nameFn = { (beloep, forventetFeil) ->
             "beløp $beloep gir ${forventetFeil.size} feil"


### PR DESCRIPTION
Legger til ny plugin fra kotest 6 som åpner for å bruke `./gradlew kotest`, som gir en mer detaljert beskrivelse under kjøring av tester. `./gradlew test` fungerer som vanlig.