### PR TITLE
Legg til nytt felt for om AGP er forespurt eller ei

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -2,6 +2,8 @@
 
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -26,6 +28,7 @@ data class Inntektsmelding(
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
 ) {
     @Serializable
+    @OptIn(ExperimentalSerializationApi::class)
     sealed class Type {
         abstract val id: UUID
 
@@ -43,12 +46,16 @@ data class Inntektsmelding(
         @SerialName("Forespurt")
         data class Forespurt(
             override val id: UUID,
+            @EncodeDefault
+            val erAgpForespurt: Boolean = true,
         ) : Type()
 
         @Serializable
         @SerialName("ForespurtEkstern")
         data class ForespurtEkstern(
             override val id: UUID,
+            @EncodeDefault
+            val erAgpForespurt: Boolean = true,
             private val _avsenderSystem: AvsenderSystem,
         ) : Type() {
             override val avsenderSystem: AvsenderSystem

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/InntektsmeldingTypeTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/InntektsmeldingTypeTest.kt
@@ -32,7 +32,11 @@ class InntektsmeldingTypeTest :
                         versjon = "AAA",
                     )
 
-                val forespurtEkstern = Inntektsmelding.Type.ForespurtEkstern(UUID.randomUUID(), eksterntAvsenderSystem)
+                val forespurtEkstern =
+                    Inntektsmelding.Type.ForespurtEkstern(
+                        id = UUID.randomUUID(),
+                        _avsenderSystem = eksterntAvsenderSystem,
+                    )
 
                 forespurtEkstern.avsenderSystem shouldBe eksterntAvsenderSystem
             }


### PR DESCRIPTION
I noen tilfeller vet AG noe vi ikke vet, som gjør kort gap om til langt. Da har vi ikke bedt om AGP, men AG vil sende allikevel. I disse tilfellene vil `erAgpForespurt` være `false`. I alle andre tilfeller så er verdien `true`.

Dersom `erAgpForespurt=false` så skal vi sende inntektsmeldingen til manuell behandling, ettersom Spleis ikke vil ha AGP dersom de ikke har bedt om det. Dette er en første versjon, så skal vi se mer på saken sammen med Spleis for å finne ut av om det kan løses på en annen måte. Se [Slack-diskusjon](https://nav-it.slack.com/archives/C044KG99LDD/p1750254732831049) for mer kontekst.