### PR TITLE
fjern egenmeldinger

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=0.8.0
+version=0.9.0
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsgiverperiode.kt
@@ -16,8 +16,6 @@ internal const val ANTALL_BEHANDLINGSDAGER = 12
 @Serializable
 data class Arbeidsgiverperiode(
     val perioder: List<Periode>,
-    // TODO vurder å fjerne om man heller kan utlede fra AGP og sykmeldingsperioder
-    val egenmeldinger: List<Periode>,
     val redusertLoennIAgp: RedusertLoennIAgp?,
 ) {
     /** Ikke-forespurt AGP _må_ indikere lengre gap til forrige sykmelding (arbeid på minst én sykmeldingsdag). */

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/ArbeidsgiverperiodeTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/ArbeidsgiverperiodeTest.kt
@@ -55,6 +55,5 @@ class ArbeidsgiverperiodeTest :
 private fun mockAgp(periode: Periode?): Arbeidsgiverperiode =
     Arbeidsgiverperiode(
         perioder = listOfNotNull(periode),
-        egenmeldinger = emptyList(),
         redusertLoennIAgp = null,
     )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -18,11 +18,6 @@ object TestData {
                             2.juni til 2.juni,
                             4.juni til 18.juni,
                         ),
-                    egenmeldinger =
-                        listOf(
-                            2.juni til 2.juni,
-                            4.juni til 5.juni,
-                        ),
                     redusertLoennIAgp =
                         RedusertLoennIAgp(
                             beloep = 34000.0,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -215,21 +215,6 @@ class SkjemaInntektsmeldingSelvbestemtTest :
 
                     skjema.valider().shouldBeEmpty()
                 }
-
-                test("egenmeldinger kan være tom") {
-                    val skjema =
-                        fulltSkjema().let {
-                            it.copy(
-                                agp =
-                                    it.agp?.copy(
-                                        egenmeldinger = emptyList(),
-                                    ),
-                            )
-                        }
-
-                    skjema.valider().shouldBeEmpty()
-                }
-
                 context(Arbeidsgiverperiode::redusertLoennIAgp.name) {
                     test("'redusertLoennIAgp' kan være 'null'") {
                         val skjema =
@@ -544,11 +529,6 @@ private fun fulltSkjema(vedtaksperiodeId: UUID = UUID.randomUUID()): SkjemaInnte
                     listOf(
                         2.juni til 2.juni,
                         4.juni til 18.juni,
-                    ),
-                egenmeldinger =
-                    listOf(
-                        2.juni til 2.juni,
-                        4.juni til 5.juni,
                     ),
                 redusertLoennIAgp =
                     RedusertLoennIAgp(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -142,7 +142,7 @@ class SkjemaInntektsmeldingTest :
 
                 context("behandlingsdager") {
 
-                    fun List<Periode>.tilArbeidsgiverperiode() = Arbeidsgiverperiode(this, emptyList(), null)
+                    fun List<Periode>.tilArbeidsgiverperiode() = Arbeidsgiverperiode(this, null)
                     val behandlingsdager = List(12) { Periode(1.januar.plusWeeks(it.toLong()), 1.januar.plusWeeks(it.toLong())) }
 
                     test("er 12 dager med en uke mellomrom") {
@@ -179,20 +179,6 @@ class SkjemaInntektsmeldingTest :
                         overAarSkifte.tilArbeidsgiverperiode().valider() shouldBe
                             listOf(FeiletValidering(Feilmelding.AGP_UNDER_16_UTEN_REDUSERT_LOENN_ELLER_BEHANDLINGSDAGER))
                     }
-                }
-
-                test("egenmeldinger kan være tom") {
-                    val skjema =
-                        TestData.fulltSkjema().let {
-                            it.copy(
-                                agp =
-                                    it.agp?.copy(
-                                        egenmeldinger = emptyList(),
-                                    ),
-                            )
-                        }
-
-                    skjema.valider().shouldBeEmpty()
                 }
 
                 context(Arbeidsgiverperiode::redusertLoennIAgp.name) {
@@ -366,7 +352,7 @@ class SkjemaInntektsmeldingTest :
                     val agpFom = 4.juni
                     val agpTom = 19.juni
 
-                    val agp = Arbeidsgiverperiode(listOf(Periode(fom = agpFom, tom = agpTom)), emptyList(), null)
+                    val agp = Arbeidsgiverperiode(listOf(Periode(fom = agpFom, tom = agpTom)), null)
                     val ugyldigRefusjon =
                         Refusjon(
                             beloepPerMaaned = 50000.0,


### PR DESCRIPTION
Det er ikke nødvendig å dele opp agp i eksplisitte egenmeldinger ved innsending eller visning, vi kan heller utlede dette fra sykmelding og innmeldt periode ved behov. 
Innfører fjerningen gradvis i simba og lps-api, se https://trello.com/c/sgwt63Ep/784-fjerne-egenmeldinger
