### PR TITLE
faisu draft

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/ArbeidsforholdDetaljer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/ArbeidsforholdDetaljer.kt
@@ -1,0 +1,11 @@
+package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ArbeidsforholdDetaljer( // TODO: Valider prosent og inntekt
+    val arbeidsforholdsId: String,
+    val inkludertISykefravaer: Boolean, // Inkludert i beregning / sykepengegrunnlag
+    val stillingsprosent: Double,
+    val inntekt: Double,
+)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.utils.json.serializer.OffsetDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.time.OffsetDateTime
@@ -27,7 +28,8 @@ data class Inntektsmelding(
     val aarsakInnsending: AarsakInnsending,
     val mottatt: OffsetDateTime,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
-) {
+    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+) : FlereArbeidsforhold {
     @Serializable
     @OptIn(ExperimentalSerializationApi::class)
     sealed class Type {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -4,6 +4,7 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.ArbeidsforholdDetaljer
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -29,7 +30,8 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-) {
+    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+) : FlereArbeidsforhold {
     fun valider(): Set<String> =
         listOfNotNull(
             listOfNotNull(
@@ -59,7 +61,8 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val refusjon: Refusjon?,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
     val arbeidsforholdType: ArbeidsforholdType,
-) {
+    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+) : FlereArbeidsforhold {
     fun valider(): Set<String> =
         listOfNotNull(
             listOfNotNull(
@@ -77,6 +80,12 @@ data class SkjemaInntektsmeldingSelvbestemt(
             validerRefusjonMotInntekt(refusjon, inntekt),
             validerRefusjonMotAgp(refusjon, agp),
         ).tilFeilmeldinger()
+}
+
+interface FlereArbeidsforhold {
+    val arbeidsforhold: List<ArbeidsforholdDetaljer>
+
+    fun erFaisu(): Boolean = arbeidsforhold.size > 1 // evt filtrer på "inkludertISykefravaer" også
 }
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -65,4 +65,25 @@ object TestData {
                         ),
                 ),
         )
+
+    fun fulltSkjemaMedFlereArbeidsforhold(): SkjemaInntektsmelding {
+        val flereArbeidsforhold =
+            listOf<ArbeidsforholdDetaljer>(
+                ArbeidsforholdDetaljer(
+                    "1",
+                    true,
+                    40.0,
+                    100.0,
+                ),
+                ArbeidsforholdDetaljer(
+                    "2",
+                    false,
+                    40.0,
+                    100.0,
+                ),
+            )
+        return fulltSkjema().copy(
+            arbeidsforhold = flereArbeidsforhold,
+        )
+    }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
@@ -68,5 +68,8 @@ class KonverterInnsendingTilInntektsmeldingTest :
             inntektsmelding.type.avsenderSystem shouldBe eksternAvsender
             inntektsmelding.type.kanal shouldBe Kanal.HR_SYSTEM_API
             inntektsmelding.avsender.navn shouldBe innsending.kontaktinfo
+            inntektsmelding.erFaisu() shouldBe false
+            val faisuIM = inntektsmelding.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
+            faisuIM.erFaisu() shouldBe true
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -16,6 +16,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.TestData
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
 import no.nav.helsearbeidsgiver.utils.json.fromJson
@@ -505,6 +506,13 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                     json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
                 deserialisertSkjema.arbeidsforholdType shouldBe arbeidsforholdType
             }
+        }
+        context("serialiser og deserialiserer flereArbeidsforhold") {
+            val vedtaksperiodeId = UUID.randomUUID()
+            val skjema = fulltSkjema(vedtaksperiodeId)
+            skjema.erFaisu() shouldBe false
+            val faisuSkjema = skjema.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
+            faisuSkjema.erFaisu() shouldBe true
         }
     })
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.TestData
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.FeiletValidering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
+import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.januar
@@ -33,6 +34,22 @@ class SkjemaInntektsmeldingTest :
                 TestData.fulltSkjema().valider().shouldBeEmpty()
             }
 
+            test("Standard Skjema er ikke type FAISU") {
+                TestData.fulltSkjema().erFaisu().shouldBe(false)
+            }
+
+            test("FAISU-skjema serialiseres OK") {
+
+                val faisuSkjema = TestData.fulltSkjemaMedFlereArbeidsforhold()
+                faisuSkjema.erFaisu() shouldBe (true)
+                val skjema = faisuSkjema.toJsonStr(SkjemaInntektsmelding.serializer())
+                println(skjema)
+                val deserialisert =
+                    kotlinx.serialization.json.Json
+                        .decodeFromString(SkjemaInntektsmelding.serializer(), skjema)
+
+                deserialisert.arbeidsforhold shouldBe faisuSkjema.arbeidsforhold
+            }
             context(SkjemaInntektsmelding::avsenderTlf.name) {
                 test("ugyldig tlf") {
                     val skjema =


### PR DESCRIPTION
Problemstilling: 
Inntektsmelding og skjema må støtte mulighet for flere arbeidsforhold. 
Dette kunne vært en egen type skjema, men vi har allerede type Forespurt og Selvbestemt, og begge disse kan ha flere arbeidsforhold. 
Ved å angi at begge typer skjema og IM implementerer nytt Interface FlereArbeidsforhold, slipper man å lage to nye typer / arv. 
Som default er liste arbeidsforhold en tom liste, da er skjema / IM en "vanlig" IM uten flere arbeidsforhold. 