### PR TITLE
Mulighet for å legge inn Flere Arbeidsforhold i Skjema

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=0.9.0
+version=0.9.1
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=0.9.2
+version=0.9.1
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=0.9.1
+version=0.9.2
 
 # Plugin versions
 kotlinVersion=2.2.20

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsforhold.kt
@@ -3,7 +3,7 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ArbeidsforholdDetaljer( // TODO: Valider prosent og inntekt
+data class Arbeidsforhold( // TODO: Valider prosent og inntekt
     val arbeidsforholdsId: String,
     val inkludertISykefravaer: Boolean, // Inkludert i beregning / sykepengegrunnlag
     val stillingsprosent: Double,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Arbeidsforhold.kt
@@ -3,9 +3,9 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Arbeidsforhold( // TODO: Valider prosent og inntekt
-    val arbeidsforholdsId: String,
+data class Arbeidsforhold( // TODO: Valider prosent og inntekt, valider, begrens og escape String beskrivelse
     val inkludertISykefravaer: Boolean, // Inkludert i beregning / sykepengegrunnlag
+    val yrkesbeskrivelse: String,
     val stillingsprosent: Double,
     val inntekt: Double,
 )

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/ArbeidsforholdDetaljer.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/ArbeidsforholdDetaljer.kt
@@ -1,0 +1,11 @@
+package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ArbeidsforholdDetaljer( // TODO: Valider prosent og inntekt
+    val arbeidsforholdsId: String,
+    val inkludertISykefravaer: Boolean, // Inkludert i beregning / sykepengegrunnlag
+    val stillingsprosent: Double,
+    val inntekt: Double,
+)

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -37,14 +37,19 @@ data class Inntektsmelding(
         open val avsenderSystem: AvsenderSystem
             get() = AvsenderSystem.nav
 
+        fun harFlereArbeidsforhold(): Boolean =
+            when (this) {
+                is Forespurt -> flereArbeidsforhold != null
+                is Selvbestemt -> flereArbeidsforhold != null
+                is Behandlingsdager, is Fisker, is ForespurtEkstern, is UtenArbeidsforhold -> false
+            }
+
         val kanal: Kanal
             get() =
                 when (this) {
                     is ForespurtEkstern -> Kanal.HR_SYSTEM_API
                     is Forespurt, is Selvbestemt, is Fisker, is UtenArbeidsforhold, is Behandlingsdager -> Kanal.NAV_NO
                 }
-
-        open fun harFlereArbeidsforhold(): Boolean = false
 
         @Serializable
         @SerialName("Forespurt")
@@ -53,9 +58,7 @@ data class Inntektsmelding(
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
             val flereArbeidsforhold: FlereArbeidsforhold? = null,
-        ) : Type() {
-            override fun harFlereArbeidsforhold(): Boolean = flereArbeidsforhold != null && flereArbeidsforhold.arbeidsforhold.isNotEmpty()
-        }
+        ) : Type()
 
         @Serializable
         @SerialName("ForespurtEkstern")
@@ -74,9 +77,7 @@ data class Inntektsmelding(
         data class Selvbestemt(
             override val id: UUID,
             val flereArbeidsforhold: FlereArbeidsforhold? = null,
-        ) : Type() {
-            override fun harFlereArbeidsforhold(): Boolean = flereArbeidsforhold != null && flereArbeidsforhold.arbeidsforhold.isNotEmpty()
-        }
+        ) : Type()
 
         @Serializable
         @SerialName("Fisker")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -52,7 +52,7 @@ data class Inntektsmelding(
             override val id: UUID,
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
-            override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+            override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
         ) : Type(),
             FlereArbeidsforhold {
             override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
@@ -65,7 +65,7 @@ data class Inntektsmelding(
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
             private val _avsenderSystem: AvsenderSystem,
-            override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+            override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
         ) : Type(),
             FlereArbeidsforhold {
             override val avsenderSystem: AvsenderSystem
@@ -78,7 +78,7 @@ data class Inntektsmelding(
         @SerialName("Selvbestemt")
         data class Selvbestemt(
             override val id: UUID,
-            override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+            override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
         ) : Type(),
             FlereArbeidsforhold {
             override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -28,8 +28,7 @@ data class Inntektsmelding(
     val aarsakInnsending: AarsakInnsending,
     val mottatt: OffsetDateTime,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
-    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
-) : FlereArbeidsforhold {
+) {
     @Serializable
     @OptIn(ExperimentalSerializationApi::class)
     sealed class Type {
@@ -45,13 +44,19 @@ data class Inntektsmelding(
                     is Forespurt, is Selvbestemt, is Fisker, is UtenArbeidsforhold, is Behandlingsdager -> Kanal.NAV_NO
                 }
 
+        open fun harFlereArbeidsforhold(): Boolean = false
+
         @Serializable
         @SerialName("Forespurt")
         data class Forespurt(
             override val id: UUID,
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
-        ) : Type()
+            override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+        ) : Type(),
+            FlereArbeidsforhold {
+            override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
+        }
 
         @Serializable
         @SerialName("ForespurtEkstern")
@@ -60,16 +65,24 @@ data class Inntektsmelding(
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
             private val _avsenderSystem: AvsenderSystem,
-        ) : Type() {
+            override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+        ) : Type(),
+            FlereArbeidsforhold {
             override val avsenderSystem: AvsenderSystem
                 get() = _avsenderSystem
+
+            override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
         }
 
         @Serializable
         @SerialName("Selvbestemt")
         data class Selvbestemt(
             override val id: UUID,
-        ) : Type()
+            override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+        ) : Type(),
+            FlereArbeidsforhold {
+            override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
+        }
 
         @Serializable
         @SerialName("Fisker")

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -8,6 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.utils.json.serializer.OffsetDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.time.OffsetDateTime
@@ -27,7 +28,8 @@ data class Inntektsmelding(
     val aarsakInnsending: AarsakInnsending,
     val mottatt: OffsetDateTime,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
-) {
+    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+) : FlereArbeidsforhold {
     @Serializable
     @OptIn(ExperimentalSerializationApi::class)
     sealed class Type {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/Inntektsmelding.kt
@@ -52,10 +52,9 @@ data class Inntektsmelding(
             override val id: UUID,
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
-            override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
-        ) : Type(),
-            FlereArbeidsforhold {
-            override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
+            val flereArbeidsforhold: FlereArbeidsforhold? = null,
+        ) : Type() {
+            override fun harFlereArbeidsforhold(): Boolean = flereArbeidsforhold != null && flereArbeidsforhold.arbeidsforhold.isNotEmpty()
         }
 
         @Serializable
@@ -65,23 +64,18 @@ data class Inntektsmelding(
             @EncodeDefault
             val erAgpForespurt: Boolean = true,
             private val _avsenderSystem: AvsenderSystem,
-            override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
-        ) : Type(),
-            FlereArbeidsforhold {
+        ) : Type() {
             override val avsenderSystem: AvsenderSystem
                 get() = _avsenderSystem
-
-            override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
         }
 
         @Serializable
         @SerialName("Selvbestemt")
         data class Selvbestemt(
             override val id: UUID,
-            override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
-        ) : Type(),
-            FlereArbeidsforhold {
-            override fun harFlereArbeidsforhold(): Boolean = arbeidsforhold.size > 1
+            val flereArbeidsforhold: FlereArbeidsforhold? = null,
+        ) : Type() {
+            override fun harFlereArbeidsforhold(): Boolean = flereArbeidsforhold != null && flereArbeidsforhold.arbeidsforhold.isNotEmpty()
         }
 
         @Serializable

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/FlereArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/FlereArbeidsforhold.kt
@@ -1,0 +1,29 @@
+package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
+
+import kotlinx.serialization.Serializable
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.FeiletValidering
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
+
+@Serializable
+data class FlereArbeidsforhold(
+    val harLikLoenn: Boolean,
+    val erSykmeldtFraAlle: Boolean,
+    val arbeidsforhold: List<Arbeidsforhold>,
+) {
+    internal fun valider(): List<FeiletValidering> =
+        listOfNotNull(
+            no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.valider(
+                vilkaar = !harLikLoenn,
+                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN,
+            ),
+            no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.valider(
+                vilkaar = !erSykmeldtFraAlle,
+                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE,
+            ),
+            no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.valider(
+                vilkaar = arbeidsforhold.size > 1,
+                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO,
+            ),
+        )
+}

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -100,6 +100,10 @@ data class FlereArbeidsforhold(
                 vilkaar = !sykmeldtFraAlle,
                 feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE,
             ),
+            valider(
+                vilkaar = arbeidsforhold.size > 1,
+                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO,
+            ),
         )
 }
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -4,6 +4,7 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.ArbeidsforholdDetaljer
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -29,7 +30,8 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-) {
+    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+) : FlereArbeidsforhold {
     fun valider(): Set<String> =
         listOfNotNull(
             listOfNotNull(
@@ -59,7 +61,8 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val refusjon: Refusjon?,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
     val arbeidsforholdType: ArbeidsforholdType,
-) {
+    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+) : FlereArbeidsforhold {
     fun valider(): Set<String> =
         listOfNotNull(
             listOfNotNull(
@@ -77,6 +80,12 @@ data class SkjemaInntektsmeldingSelvbestemt(
             validerRefusjonMotInntekt(refusjon, inntekt),
             validerRefusjonMotAgp(refusjon, agp),
         ).tilFeilmeldinger()
+}
+
+interface FlereArbeidsforhold {
+    val arbeidsforhold: List<ArbeidsforholdDetaljer>
+
+    fun erFaisu(): Boolean = arbeidsforhold.size > 1 // evt filtrer på "inkludertISykefravaer" også
 }
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -30,8 +30,8 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-    override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
-) : FlereArbeidsforhold {
+    val flereArbeidsforhold: FlereArbeidsforhold? = null, // Liker ikke defaults i request-klasser, men enn så lenge (?) trengs det for å lese gamle databaserader.
+) {
     fun valider(): Set<String> =
         listOfNotNull(
             listOfNotNull(
@@ -61,8 +61,8 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val refusjon: Refusjon?,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
     val arbeidsforholdType: ArbeidsforholdType,
-    override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
-) : FlereArbeidsforhold {
+    val flereArbeidsforhold: FlereArbeidsforhold? = null,
+) {
     fun valider(): Set<String> =
         listOfNotNull(
             listOfNotNull(
@@ -82,9 +82,12 @@ data class SkjemaInntektsmeldingSelvbestemt(
         ).tilFeilmeldinger()
 }
 
-interface FlereArbeidsforhold {
-    val arbeidsforhold: List<Arbeidsforhold>
-}
+@Serializable
+data class FlereArbeidsforhold(
+    val harLikLoenn: Boolean,
+    val sykmeldtFraAlle: Boolean,
+    val arbeidsforhold: List<Arbeidsforhold>,
+)
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =
     listOfNotNull(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -44,6 +44,7 @@ data class SkjemaInntektsmelding(
             inntekt?.valider(),
             naturalytelser.valider(),
             refusjon?.valider(),
+            flereArbeidsforhold?.valider(),
             validerRefusjonMotInntekt(refusjon, inntekt),
             validerRefusjonMotAgp(refusjon, agp),
         ).tilFeilmeldinger()
@@ -87,7 +88,19 @@ data class FlereArbeidsforhold(
     val harLikLoenn: Boolean,
     val sykmeldtFraAlle: Boolean,
     val arbeidsforhold: List<Arbeidsforhold>,
-)
+) {
+    internal fun valider(): List<FeiletValidering> =
+        listOfNotNull(
+            valider(
+                vilkaar = !harLikLoenn,
+                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN,
+            ),
+            valider(
+                vilkaar = !sykmeldtFraAlle,
+                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE,
+            ),
+        )
+}
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =
     listOfNotNull(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -88,29 +87,6 @@ data class SkjemaInntektsmeldingSelvbestemt(
             validerRefusjonMotInntekt(refusjon, inntekt),
             validerRefusjonMotAgp(refusjon, agp),
         ).tilFeilmeldinger()
-}
-
-@Serializable
-data class FlereArbeidsforhold(
-    val harLikLoenn: Boolean,
-    val erSykmeldtFraAlle: Boolean,
-    val arbeidsforhold: List<Arbeidsforhold>,
-) {
-    internal fun valider(): List<FeiletValidering> =
-        listOfNotNull(
-            valider(
-                vilkaar = !harLikLoenn,
-                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN,
-            ),
-            valider(
-                vilkaar = !erSykmeldtFraAlle,
-                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE,
-            ),
-            valider(
-                vilkaar = arbeidsforhold.size > 1,
-                feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO,
-            ),
-        )
 }
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -84,8 +84,6 @@ data class SkjemaInntektsmeldingSelvbestemt(
 
 interface FlereArbeidsforhold {
     val arbeidsforhold: List<ArbeidsforholdDetaljer>
-
-    fun erFaisu(): Boolean = arbeidsforhold.size > 1 // evt filtrer på "inkludertISykefravaer" også
 }
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -2,6 +2,8 @@
 
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
@@ -22,6 +24,7 @@ import java.util.UUID
 
 private val sikkerLogger = sikkerLogger()
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SkjemaInntektsmelding(
     val forespoerselId: UUID,
@@ -30,7 +33,8 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-    val flereArbeidsforhold: FlereArbeidsforhold? = null, // Liker ikke defaults i request-klasser, trengs for å lese gamle databaserader
+    @EncodeDefault
+    val flereArbeidsforhold: FlereArbeidsforhold? = null, // default trengs for å lese gamle databaserader
 ) {
     fun valider(): Set<String> =
         listOfNotNull(
@@ -50,6 +54,7 @@ data class SkjemaInntektsmelding(
         ).tilFeilmeldinger()
 }
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SkjemaInntektsmeldingSelvbestemt(
     val selvbestemtId: UUID?,
@@ -62,6 +67,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val refusjon: Refusjon?,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
     val arbeidsforholdType: ArbeidsforholdType,
+    @EncodeDefault
     val flereArbeidsforhold: FlereArbeidsforhold? = null,
 ) {
     fun valider(): Set<String> =
@@ -87,7 +93,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
 @Serializable
 data class FlereArbeidsforhold(
     val harLikLoenn: Boolean,
-    val sykmeldtFraAlle: Boolean,
+    val erSykmeldtFraAlle: Boolean,
     val arbeidsforhold: List<Arbeidsforhold>,
 ) {
     internal fun valider(): List<FeiletValidering> =
@@ -97,7 +103,7 @@ data class FlereArbeidsforhold(
                 feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN,
             ),
             valider(
-                vilkaar = !sykmeldtFraAlle,
+                vilkaar = !erSykmeldtFraAlle,
                 feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE,
             ),
             valider(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -4,7 +4,7 @@ package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.ArbeidsforholdDetaljer
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -30,7 +30,7 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+    override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
 ) : FlereArbeidsforhold {
     fun valider(): Set<String> =
         listOfNotNull(
@@ -61,7 +61,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
     val refusjon: Refusjon?,
     val vedtaksperiodeId: UUID? = null, // nullable for å støtte fisker og utenArbeidsforhold
     val arbeidsforholdType: ArbeidsforholdType,
-    override val arbeidsforhold: List<ArbeidsforholdDetaljer> = emptyList(),
+    override val arbeidsforhold: List<Arbeidsforhold> = emptyList(),
 ) : FlereArbeidsforhold {
     fun valider(): Set<String> =
         listOfNotNull(
@@ -83,7 +83,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
 }
 
 interface FlereArbeidsforhold {
-    val arbeidsforhold: List<ArbeidsforholdDetaljer>
+    val arbeidsforhold: List<Arbeidsforhold>
 }
 
 private fun List<Naturalytelse>.valider(): List<FeiletValidering> =

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -30,7 +30,7 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-    val flereArbeidsforhold: FlereArbeidsforhold? = null, // Liker ikke defaults i request-klasser, men enn så lenge (?) trengs det for å lese gamle databaserader.
+    val flereArbeidsforhold: FlereArbeidsforhold? = null, // Liker ikke defaults i request-klasser, men trengs for å lese gamle databaserader.
 ) {
     fun valider(): Set<String> =
         listOfNotNull(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -30,7 +30,7 @@ data class SkjemaInntektsmelding(
     val inntekt: Inntekt?,
     val naturalytelser: List<Naturalytelse>,
     val refusjon: Refusjon?,
-    val flereArbeidsforhold: FlereArbeidsforhold? = null, // Liker ikke defaults i request-klasser, men trengs for å lese gamle databaserader.
+    val flereArbeidsforhold: FlereArbeidsforhold? = null, // Liker ikke defaults i request-klasser, trengs for å lese gamle databaserader
 ) {
     fun valider(): Set<String> =
         listOfNotNull(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmelding.kt
@@ -77,6 +77,7 @@ data class SkjemaInntektsmeldingSelvbestemt(
             inntekt.valider(),
             naturalytelser.valider(),
             refusjon?.valider(),
+            flereArbeidsforhold?.valider(),
             validerBestemmendeFravaersdagMotInntektsdato(agp, inntekt, sykmeldingsperioder),
             validerRefusjonMotInntekt(refusjon, inntekt),
             validerRefusjonMotAgp(refusjon, agp),

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -27,6 +27,9 @@ internal object Feilmelding {
     const val REFUSJON_ENDRING_FOER_INNTEKTDATO = "Startdato for refusjonsendringer må være etter inntektdato"
     const val DUPLIKAT_INNTEKT_ENDRINGSAARSAK = "Endringsårsaker kan ikke inneholde duplikater"
 
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN = "Ved innsending av flere arbeidsforhold må de ha ulik lønn"
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE = "Ved innsending av flere arbeidsforhold kan det ikke være sykefravær fra alle"
+
     // Feil i koden, ingenting bruker kan gjøre
     const val TEKNISK_FEIL = "Det oppsto en feil i systemet. Prøv igjen senere."
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -27,6 +27,7 @@ internal object Feilmelding {
     const val REFUSJON_ENDRING_FOER_INNTEKTDATO = "Startdato for refusjonsendringer må være etter inntektdato"
     const val DUPLIKAT_INNTEKT_ENDRINGSAARSAK = "Endringsårsaker kan ikke inneholde duplikater"
 
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO = "Flere arbeidsforhold må inneholde minst to"
     const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN = "Ved innsending av flere arbeidsforhold må de ha ulik lønn"
     const val UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE = "Ved innsending av flere arbeidsforhold kan det ikke være sykefravær fra alle"
 

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -27,7 +27,7 @@ internal object Feilmelding {
     const val REFUSJON_ENDRING_FOER_INNTEKTDATO = "Startdato for refusjonsendringer må være etter inntektdato"
     const val DUPLIKAT_INNTEKT_ENDRINGSAARSAK = "Endringsårsaker kan ikke inneholde duplikater"
 
-    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO = "Flere arbeidsforhold må inneholde minst to"
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO = "Flere arbeidsforhold må inneholde minst to arbeidsforhold"
     const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN = "Ved innsending av flere arbeidsforhold må de ha ulik lønn"
     const val UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE = "Ved innsending av flere arbeidsforhold kan det ikke være sykefravær fra alle"
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -70,14 +70,14 @@ object TestData {
         val flereArbeidsforhold =
             listOf<Arbeidsforhold>(
                 Arbeidsforhold(
-                    "1",
                     true,
+                    "Snekker",
                     40.0,
                     100.0,
                 ),
                 Arbeidsforhold(
-                    "2",
                     false,
+                    "Stuntmann",
                     40.0,
                     100.0,
                 ),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -70,22 +70,23 @@ object TestData {
     fun fulltSkjemaMedFlereArbeidsforhold(): SkjemaInntektsmelding {
         val flereArbeidsforhold =
             FlereArbeidsforhold(
-                false,
-                false,
-                listOf<Arbeidsforhold>(
-                    Arbeidsforhold(
-                        true,
-                        "Snekker",
-                        40.0,
-                        100.0,
+                harLikLoenn = false,
+                erSykmeldtFraAlle = false,
+                arbeidsforhold =
+                    listOf<Arbeidsforhold>(
+                        Arbeidsforhold(
+                            inkludertISykefravaer = true,
+                            yrkesbeskrivelse = "Snekker",
+                            stillingsprosent = 40.0,
+                            inntekt = 100.0,
+                        ),
+                        Arbeidsforhold(
+                            inkludertISykefravaer = false,
+                            yrkesbeskrivelse = "Stuntmann",
+                            stillingsprosent = 40.0,
+                            inntekt = 100.0,
+                        ),
                     ),
-                    Arbeidsforhold(
-                        false,
-                        "Stuntmann",
-                        40.0,
-                        100.0,
-                    ),
-                ),
             )
         return fulltSkjema().copy(
             flereArbeidsforhold = flereArbeidsforhold,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -65,4 +65,25 @@ object TestData {
                         ),
                 ),
         )
+
+    fun fulltSkjemaMedFlereArbeidsforhold(): SkjemaInntektsmelding {
+        val flereArbeidsforhold =
+            listOf<ArbeidsforholdDetaljer>(
+                ArbeidsforholdDetaljer(
+                    "1",
+                    true,
+                    40.0,
+                    100.0,
+                ),
+                ArbeidsforholdDetaljer(
+                    "2",
+                    false,
+                    40.0,
+                    100.0,
+                ),
+            )
+        return fulltSkjema().copy(
+            arbeidsforhold = flereArbeidsforhold,
+        )
+    }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -68,14 +68,14 @@ object TestData {
 
     fun fulltSkjemaMedFlereArbeidsforhold(): SkjemaInntektsmelding {
         val flereArbeidsforhold =
-            listOf<ArbeidsforholdDetaljer>(
-                ArbeidsforholdDetaljer(
+            listOf<Arbeidsforhold>(
+                Arbeidsforhold(
                     "1",
                     true,
                     40.0,
                     100.0,
                 ),
-                ArbeidsforholdDetaljer(
+                Arbeidsforhold(
                     "2",
                     false,
                     40.0,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -1,5 +1,6 @@
 package no.nav.helsearbeidsgiver.domene.inntektsmelding.v1
 
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.utils.test.date.juli
 import no.nav.helsearbeidsgiver.utils.test.date.juni
@@ -68,22 +69,26 @@ object TestData {
 
     fun fulltSkjemaMedFlereArbeidsforhold(): SkjemaInntektsmelding {
         val flereArbeidsforhold =
-            listOf<Arbeidsforhold>(
-                Arbeidsforhold(
-                    true,
-                    "Snekker",
-                    40.0,
-                    100.0,
-                ),
-                Arbeidsforhold(
-                    false,
-                    "Stuntmann",
-                    40.0,
-                    100.0,
+            FlereArbeidsforhold(
+                false,
+                false,
+                listOf<Arbeidsforhold>(
+                    Arbeidsforhold(
+                        true,
+                        "Snekker",
+                        40.0,
+                        100.0,
+                    ),
+                    Arbeidsforhold(
+                        false,
+                        "Stuntmann",
+                        40.0,
+                        100.0,
+                    ),
                 ),
             )
         return fulltSkjema().copy(
-            arbeidsforhold = flereArbeidsforhold,
+            flereArbeidsforhold = flereArbeidsforhold,
         )
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
@@ -75,7 +75,7 @@ class KonverterInnsendingTilInntektsmeldingTest :
                     type =
                         Type.Forespurt(
                             id = UUID.randomUUID(),
-                            arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold,
+                            flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold,
                         ),
                 )
             faisuIM.type.harFlereArbeidsforhold() shouldBe true

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
@@ -68,5 +68,8 @@ class KonverterInnsendingTilInntektsmeldingTest :
             inntektsmelding.type.avsenderSystem shouldBe eksternAvsender
             inntektsmelding.type.kanal shouldBe Kanal.HR_SYSTEM_API
             inntektsmelding.avsender.navn shouldBe innsending.kontaktinfo
+            inntektsmelding.erFaisu() shouldBe false
+            val faisuIM = inntektsmelding.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
+            faisuIM.erFaisu() shouldBe true
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding.Type
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Kanal
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.TestData
@@ -68,8 +69,15 @@ class KonverterInnsendingTilInntektsmeldingTest :
             inntektsmelding.type.avsenderSystem shouldBe eksternAvsender
             inntektsmelding.type.kanal shouldBe Kanal.HR_SYSTEM_API
             inntektsmelding.avsender.navn shouldBe innsending.kontaktinfo
-            inntektsmelding.erFaisu() shouldBe false
-            val faisuIM = inntektsmelding.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
-            faisuIM.erFaisu() shouldBe true
+            inntektsmelding.type.harFlereArbeidsforhold() shouldBe false
+            val faisuIM =
+                inntektsmelding.copy(
+                    type =
+                        Type.Forespurt(
+                            id = UUID.randomUUID(),
+                            arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold,
+                        ),
+                )
+            faisuIM.type.harFlereArbeidsforhold() shouldBe true
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/api/KonverterInnsendingTilInntektsmeldingTest.kt
@@ -18,50 +18,50 @@ import java.util.UUID
 class KonverterInnsendingTilInntektsmeldingTest :
     FunSpec({
 
+        val eksternAvsender =
+            AvsenderSystem(
+                orgnr = Orgnr.genererGyldig(),
+                navn = "TestSystem",
+                versjon = "1",
+            )
+        val innsending =
+            Innsending(
+                innsendingId = UUID.randomUUID(),
+                skjema = TestData.fulltSkjema(),
+                aarsakInnsending = AarsakInnsending.Ny,
+                type =
+                    Type.ForespurtEkstern(
+                        id = UUID.randomUUID(),
+                        _avsenderSystem = eksternAvsender,
+                    ),
+                innsendtTid = OffsetDateTime.now(),
+                kontaktinfo = "kontaktinformasjon",
+            )
+        val inntektsmelding =
+            Inntektsmelding(
+                id = innsending.innsendingId,
+                type = innsending.type,
+                sykmeldt = Sykmeldt(Fnr.genererGyldig(), "Navn Navnesen"), // Fnr hentes fra fsp, navn slås opp i berik-steg
+                avsender =
+                    Avsender(
+                        // orgnr på bedrift kommer fra fsp
+                        orgnr = Orgnr.genererGyldig(),
+                        orgNavn = "TestBedrift",
+                        navn = innsending.kontaktinfo,
+                        tlf = innsending.skjema.avsenderTlf,
+                    ),
+                sykmeldingsperioder = emptyList(), // slå opp fra fsp..
+                agp = innsending.skjema.agp,
+                inntekt = innsending.skjema.inntekt,
+                naturalytelser = innsending.skjema.naturalytelser,
+                refusjon = innsending.skjema.refusjon,
+                aarsakInnsending = innsending.aarsakInnsending,
+                mottatt = innsending.innsendtTid,
+                vedtaksperiodeId = UUID.randomUUID(), // hente fra fsp...
+            )
         test("En innsending skal inneholde (nesten) nok informasjon til at man kan bygge en ferdig inntektsmelding") {
             // Denne testen er nå mest for å sjekke at formatene er kompatible,
             // at vi får sendt nok informasjon inn, og kan få tilbake nok info etter berikelse
-            val eksternAvsender =
-                AvsenderSystem(
-                    orgnr = Orgnr.genererGyldig(),
-                    navn = "TestSystem",
-                    versjon = "1",
-                )
-            val innsending =
-                Innsending(
-                    innsendingId = UUID.randomUUID(),
-                    skjema = TestData.fulltSkjema(),
-                    aarsakInnsending = AarsakInnsending.Ny,
-                    type =
-                        Inntektsmelding.Type.ForespurtEkstern(
-                            id = UUID.randomUUID(),
-                            _avsenderSystem = eksternAvsender,
-                        ),
-                    innsendtTid = OffsetDateTime.now(),
-                    kontaktinfo = "kontaktinformasjon",
-                )
-            val inntektsmelding =
-                Inntektsmelding(
-                    id = innsending.innsendingId,
-                    type = innsending.type,
-                    sykmeldt = Sykmeldt(Fnr.genererGyldig(), "Navn Navnesen"), // Fnr hentes fra fsp, navn slås opp i berik-steg
-                    avsender =
-                        Avsender(
-                            // orgnr på bedrift kommer fra fsp
-                            orgnr = Orgnr.genererGyldig(),
-                            orgNavn = "TestBedrift",
-                            navn = innsending.kontaktinfo,
-                            tlf = innsending.skjema.avsenderTlf,
-                        ),
-                    sykmeldingsperioder = emptyList(), // slå opp fra fsp..
-                    agp = innsending.skjema.agp,
-                    inntekt = innsending.skjema.inntekt,
-                    naturalytelser = innsending.skjema.naturalytelser,
-                    refusjon = innsending.skjema.refusjon,
-                    aarsakInnsending = innsending.aarsakInnsending,
-                    mottatt = innsending.innsendtTid,
-                    vedtaksperiodeId = UUID.randomUUID(), // hente fra fsp...
-                )
             inntektsmelding.inntekt shouldBe innsending.skjema.inntekt
             inntektsmelding.refusjon shouldBe innsending.skjema.refusjon
             inntektsmelding.agp shouldBe innsending.skjema.agp
@@ -69,12 +69,16 @@ class KonverterInnsendingTilInntektsmeldingTest :
             inntektsmelding.type.avsenderSystem shouldBe eksternAvsender
             inntektsmelding.type.kanal shouldBe Kanal.HR_SYSTEM_API
             inntektsmelding.avsender.navn shouldBe innsending.kontaktinfo
+        }
+
+        test("Flere arbeidsforhold i inntektsmelding") {
             inntektsmelding.type.harFlereArbeidsforhold() shouldBe false
             val faisuIM =
                 inntektsmelding.copy(
                     type =
                         Type.Forespurt(
                             id = UUID.randomUUID(),
+                            erAgpForespurt = true,
                             flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold,
                         ),
                 )

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -510,9 +510,8 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                 deserialisertSkjema.arbeidsforholdType shouldBe arbeidsforholdType
             }
         }
-        context("serialiser og deserialiserer Selvbestemt med flereArbeidsforhold") {
-            val vedtaksperiodeId = UUID.randomUUID()
-            val skjema = fulltSkjema(vedtaksperiodeId)
+        test("serialiser og deserialiserer Selvbestemt med flereArbeidsforhold") {
+            val skjema = fulltSkjema(vedtaksperiodeId = UUID.randomUUID())
 
             val faisuSkjema = skjema.copy(flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold)
             val json = faisuSkjema.toJsonStr(SkjemaInntektsmeldingSelvbestemt.serializer())
@@ -522,9 +521,8 @@ class SkjemaInntektsmeldingSelvbestemtTest :
             val im = json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
             im.flereArbeidsforhold shouldBe TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold
         }
-        context("validerer flereArbeidsforhold") {
-            val vedtaksperiodeId = UUID.randomUUID()
-            val skjema = fulltSkjema(vedtaksperiodeId)
+        test("validerer flereArbeidsforhold") {
+            val skjema = fulltSkjema(vedtaksperiodeId = UUID.randomUUID())
 
             val faisuSkjema = skjema.copy(flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold)
             faisuSkjema.valider().shouldBeEmpty()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -516,7 +516,7 @@ class SkjemaInntektsmeldingSelvbestemtTest :
             val faisuSkjema = skjema.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
             val json = faisuSkjema.toJsonStr(SkjemaInntektsmeldingSelvbestemt.serializer())
             json.shouldContain(
-                """"arbeidsforhold":[{"arbeidsforholdsId":"1","inkludertISykefravaer":true,"stillingsprosent":40.0,"inntekt":100.0},{"arbeidsforholdsId":"2","inkludertISykefravaer":false,"stillingsprosent":40.0,"inntekt":100.0}]""",
+                """"arbeidsforhold":[{"inkludertISykefravaer":true,"yrkesbeskrivelse":"Snekker","stillingsprosent":40.0,"inntekt":100.0},{"inkludertISykefravaer":false,"yrkesbeskrivelse":"Stuntmann","stillingsprosent":40.0,"inntekt":100.0}]""",
             )
             val im = json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
             im.arbeidsforhold shouldBe TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -6,6 +6,7 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.json.jsonObject
@@ -21,6 +22,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.juli
 import no.nav.helsearbeidsgiver.utils.test.date.juni
@@ -507,12 +509,17 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                 deserialisertSkjema.arbeidsforholdType shouldBe arbeidsforholdType
             }
         }
-        context("serialiser og deserialiserer flereArbeidsforhold") {
+        context("serialiser og deserialiserer Selvbestemt med flereArbeidsforhold") {
             val vedtaksperiodeId = UUID.randomUUID()
             val skjema = fulltSkjema(vedtaksperiodeId)
-            skjema.erFaisu() shouldBe false
+
             val faisuSkjema = skjema.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
-            faisuSkjema.erFaisu() shouldBe true
+            val json = faisuSkjema.toJsonStr(SkjemaInntektsmeldingSelvbestemt.serializer())
+            json.shouldContain(
+                """"arbeidsforhold":[{"arbeidsforholdsId":"1","inkludertISykefravaer":true,"stillingsprosent":40.0,"inntekt":100.0},{"arbeidsforholdsId":"2","inkludertISykefravaer":false,"stillingsprosent":40.0,"inntekt":100.0}]""",
+            )
+            val im = json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
+            im.arbeidsforhold shouldBe TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold
         }
     })
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -16,6 +16,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.TestData
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
 import no.nav.helsearbeidsgiver.utils.json.fromJson
@@ -505,6 +506,13 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                     json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
                 deserialisertSkjema.arbeidsforholdType shouldBe arbeidsforholdType
             }
+        }
+        context("serialiser og deserialiserer flereArbeidsforhold") {
+            val vedtaksperiodeId = UUID.randomUUID()
+            val skjema = fulltSkjema(vedtaksperiodeId)
+            skjema.erFaisu() shouldBe false
+            val faisuSkjema = skjema.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
+            faisuSkjema.erFaisu() shouldBe true
         }
     })
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -513,13 +513,13 @@ class SkjemaInntektsmeldingSelvbestemtTest :
             val vedtaksperiodeId = UUID.randomUUID()
             val skjema = fulltSkjema(vedtaksperiodeId)
 
-            val faisuSkjema = skjema.copy(arbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold)
+            val faisuSkjema = skjema.copy(flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold)
             val json = faisuSkjema.toJsonStr(SkjemaInntektsmeldingSelvbestemt.serializer())
             json.shouldContain(
                 """"arbeidsforhold":[{"inkludertISykefravaer":true,"yrkesbeskrivelse":"Snekker","stillingsprosent":40.0,"inntekt":100.0},{"inkludertISykefravaer":false,"yrkesbeskrivelse":"Stuntmann","stillingsprosent":40.0,"inntekt":100.0}]""",
             )
             val im = json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
-            im.arbeidsforhold shouldBe TestData.fulltSkjemaMedFlereArbeidsforhold().arbeidsforhold
+            im.flereArbeidsforhold shouldBe TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold
         }
     })
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.ExperimentalSerializationApi
@@ -520,6 +521,15 @@ class SkjemaInntektsmeldingSelvbestemtTest :
             )
             val im = json.fromJson(SkjemaInntektsmeldingSelvbestemt.serializer())
             im.flereArbeidsforhold shouldBe TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold
+        }
+        context("validerer flereArbeidsforhold") {
+            val vedtaksperiodeId = UUID.randomUUID()
+            val skjema = fulltSkjema(vedtaksperiodeId)
+
+            val faisuSkjema = skjema.copy(flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold)
+            faisuSkjema.valider().shouldBeEmpty()
+            val ugyldig = faisuSkjema.copy(flereArbeidsforhold = FlereArbeidsforhold(true, false, emptyList()))
+            ugyldig.valider().shouldNotBeEmpty()
         }
     })
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.TestData
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.FeiletValidering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
+import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.desember
@@ -34,21 +35,12 @@ class SkjemaInntektsmeldingTest :
                 TestData.fulltSkjema().valider().shouldBeEmpty()
             }
 
-            test("Standard Skjema er ikke type FAISU") {
-                TestData.fulltSkjema().erFaisu().shouldBe(false)
-            }
-
-            test("FAISU-skjema serialiseres OK") {
+            test("Serialiser og deserialiser FAISU-skjema OK") {
 
                 val faisuSkjema = TestData.fulltSkjemaMedFlereArbeidsforhold()
-                faisuSkjema.erFaisu() shouldBe (true)
                 val skjema = faisuSkjema.toJsonStr(SkjemaInntektsmelding.serializer())
-                println(skjema)
-                val deserialisert =
-                    kotlinx.serialization.json.Json
-                        .decodeFromString(SkjemaInntektsmelding.serializer(), skjema)
-
-                deserialisert.arbeidsforhold shouldBe faisuSkjema.arbeidsforhold
+                val im = skjema.fromJson(SkjemaInntektsmelding.serializer())
+                im.arbeidsforhold shouldBe faisuSkjema.arbeidsforhold
             }
             context(SkjemaInntektsmelding::avsenderTlf.name) {
                 test("ugyldig tlf") {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -303,9 +303,9 @@ class SkjemaInntektsmeldingTest :
             context("Flere Arbeidsforhold") {
                 test("Bruker må svare nei på både lik lønn og sykmeldt fra alle forhold for at IM er gyldig") {
                     TestData.fulltSkjemaMedFlereArbeidsforhold().valider().shouldBeEmpty()
-                    val standardFlereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold!!
-                    val ugyldigMedLikLoenn = standardFlereArbeidsforhold.copy(harLikLoenn = true)
-                    val ugyldigMedSykmeldtAlle = standardFlereArbeidsforhold.copy(sykmeldtFraAlle = true)
+                    val flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold!!
+                    val ugyldigMedLikLoenn = flereArbeidsforhold.copy(harLikLoenn = true)
+                    val ugyldigMedSykmeldtAlle = flereArbeidsforhold.copy(sykmeldtFraAlle = true)
                     val ugyldigBegge = ugyldigMedLikLoenn.copy(sykmeldtFraAlle = true)
                     ugyldigMedLikLoenn.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN)
                     ugyldigMedSykmeldtAlle.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -40,7 +40,7 @@ class SkjemaInntektsmeldingTest :
                 val faisuSkjema = TestData.fulltSkjemaMedFlereArbeidsforhold()
                 val skjema = faisuSkjema.toJsonStr(SkjemaInntektsmelding.serializer())
                 val im = skjema.fromJson(SkjemaInntektsmelding.serializer())
-                im.arbeidsforhold shouldBe faisuSkjema.arbeidsforhold
+                im.flereArbeidsforhold shouldBe faisuSkjema.flereArbeidsforhold
             }
             context(SkjemaInntektsmelding::avsenderTlf.name) {
                 test("ugyldig tlf") {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -4,7 +4,9 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.core.spec.style.scopes.FunSpecContainerScope
 import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
@@ -295,6 +297,25 @@ class SkjemaInntektsmeldingTest :
                         )
 
                     skjema.valider() shouldContainAll forventetFeil
+                }
+            }
+
+            context("Flere Arbeidsforhold") {
+                test("Bruker må svare nei på både lik lønn og sykmeldt fra alle forhold for at IM er gyldig") {
+                    TestData.fulltSkjemaMedFlereArbeidsforhold().valider().shouldBeEmpty()
+                    val standardFlereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold!!
+                    val ugyldigMedLikLoenn = standardFlereArbeidsforhold.copy(harLikLoenn = true)
+                    val ugyldigMedSykmeldtAlle = standardFlereArbeidsforhold.copy(sykmeldtFraAlle = true)
+                    val ugyldigBegge = ugyldigMedLikLoenn.copy(sykmeldtFraAlle = true)
+                    ugyldigMedLikLoenn.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN)
+                    ugyldigMedSykmeldtAlle.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE)
+                    ugyldigBegge.valider().shouldNotBeEmpty()
+                    // Verifiser at skjema kaller arbeidsforhold.valider() også:
+                    TestData
+                        .fulltSkjema()
+                        .copy(flereArbeidsforhold = ugyldigBegge)
+                        .valider()
+                        .shouldNotBeEmpty()
                 }
             }
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -305,8 +305,8 @@ class SkjemaInntektsmeldingTest :
                     TestData.fulltSkjemaMedFlereArbeidsforhold().valider().shouldBeEmpty()
                     val flereArbeidsforhold = TestData.fulltSkjemaMedFlereArbeidsforhold().flereArbeidsforhold!!
                     val ugyldigMedLikLoenn = flereArbeidsforhold.copy(harLikLoenn = true)
-                    val ugyldigMedSykmeldtAlle = flereArbeidsforhold.copy(sykmeldtFraAlle = true)
-                    val ugyldigBegge = ugyldigMedLikLoenn.copy(sykmeldtFraAlle = true)
+                    val ugyldigMedSykmeldtAlle = flereArbeidsforhold.copy(erSykmeldtFraAlle = true)
+                    val ugyldigBegge = ugyldigMedLikLoenn.copy(erSykmeldtFraAlle = true)
                     ugyldigMedLikLoenn.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN)
                     ugyldigMedSykmeldtAlle.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE)
                     ugyldigBegge.valider().shouldNotBeEmpty()

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.TestData
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.FeiletValidering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
+import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.januar
@@ -33,6 +34,22 @@ class SkjemaInntektsmeldingTest :
                 TestData.fulltSkjema().valider().shouldBeEmpty()
             }
 
+            test("Standard Skjema er ikke type FAISU") {
+                TestData.fulltSkjema().erFaisu().shouldBe(false)
+            }
+
+            test("FAISU-skjema serialiseres OK") {
+
+                val faisuSkjema = TestData.fulltSkjemaMedFlereArbeidsforhold()
+                faisuSkjema.erFaisu() shouldBe (true)
+                val skjema = faisuSkjema.toJsonStr(SkjemaInntektsmelding.serializer())
+                println(skjema)
+                val deserialisert =
+                    kotlinx.serialization.json.Json
+                        .decodeFromString(SkjemaInntektsmelding.serializer(), skjema)
+
+                deserialisert.arbeidsforhold shouldBe faisuSkjema.arbeidsforhold
+            }
             context(SkjemaInntektsmelding::avsenderTlf.name) {
                 test("ugyldig tlf") {
                     val skjema =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -317,6 +317,10 @@ class SkjemaInntektsmeldingTest :
                         .valider()
                         .shouldNotBeEmpty()
                 }
+                test("Må ha flere arbeidsforhold") {
+                    val ugyldig = FlereArbeidsforhold(false, false, emptyList())
+                    ugyldig.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MAA_HA_MINST_TO)
+                }
             }
 
             context(SkjemaInntektsmelding::refusjon.name) {


### PR DESCRIPTION
Denne varianten er forskjellig fra Alt.1 ved at her legges flereArbeidsforhold og listen inne i Inntektsmelding.Type - 
i alt 1 var det mulig at en IM av typen "UtenArbeidsforhold"  kunne ha en liste med arbeidsforhold, som kanskje ikke gir mening.. 
