### PR TITLE
Flere arbeidsforhold: Fjern støtte for endringer

### DIFF
--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/FlereArbeidsforhold.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/FlereArbeidsforhold.kt
@@ -10,14 +10,13 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.valider
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import java.math.BigDecimal
-import java.time.LocalDate
 import kotlin.collections.sumOf
 
 @Serializable
 data class FlereArbeidsforhold(
     val harLikLoenn: Boolean,
     val erSykmeldtFraAlle: Boolean,
-    val arbeidsforholdPerSykmeldingStartdato: Map<LocalDate, List<Arbeidsforhold>>,
+    val arbeidsforhold: List<Arbeidsforhold>,
 ) {
     internal fun valider(): List<FeiletValidering> {
         val overordnedeFeil =
@@ -30,31 +29,25 @@ data class FlereArbeidsforhold(
                     vilkaar = !erSykmeldtFraAlle,
                     feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE,
                 ),
-                valider(
-                    vilkaar = arbeidsforholdPerSykmeldingStartdato.isNotEmpty(),
-                    feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_IKKE_TOM,
-                ),
             )
 
         val feilPaaTversAvArbeidsforhold =
-            arbeidsforholdPerSykmeldingStartdato.values.flatMap { arbeidsforhold ->
-                listOfNotNull(
-                    valider(
-                        vilkaar = arbeidsforhold.size >= 2,
-                        feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_MINST_TO,
-                    ),
-                    valider(
-                        vilkaar = arbeidsforhold.any { it.inkludertISykefravaer },
-                        feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INGEN_ARBEIDSFORHOLD,
-                    ),
-                    valider(
-                        vilkaar = !arbeidsforhold.all { it.inkludertISykefravaer },
-                        feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_ALLE_ARBEIDSFORHOLD,
-                    ),
-                )
-            }
+            listOfNotNull(
+                valider(
+                    vilkaar = arbeidsforhold.size >= 2,
+                    feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MINST_TO,
+                ),
+                valider(
+                    vilkaar = arbeidsforhold.any { it.inkludertISykefravaer },
+                    feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_INGEN_ARBEIDSFORHOLD,
+                ),
+                valider(
+                    vilkaar = !arbeidsforhold.all { it.inkludertISykefravaer },
+                    feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_ALLE_ARBEIDSFORHOLD,
+                ),
+            )
 
-        val feilIEnkelteArbeidsforhold = arbeidsforholdPerSykmeldingStartdato.values.flatten().flatMap { it.valider() }
+        val feilIEnkelteArbeidsforhold = arbeidsforhold.flatMap { it.valider() }
 
         return overordnedeFeil + feilPaaTversAvArbeidsforhold + feilIEnkelteArbeidsforhold
     }
@@ -65,8 +58,8 @@ data class FlereArbeidsforhold(
                 FeiletValidering(Feilmelding.TEKNISK_FEIL)
             } else {
                 valider(
-                    vilkaar = sumInntektPerStartdato().all { it == inntekt.beloep },
-                    feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INNTEKT_AVVIK,
+                    vilkaar = sumInntekt() == inntekt.beloep,
+                    feilmelding = Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_INNTEKT_AVVIK,
                 )
             },
         )
@@ -83,8 +76,5 @@ data class FlereArbeidsforhold(
             },
         )
 
-    private fun sumInntektPerStartdato(): List<Double> =
-        arbeidsforholdPerSykmeldingStartdato.values.map { arbeidsforhold ->
-            arbeidsforhold.sumOf { BigDecimal.valueOf(it.inntekt) }.toDouble()
-        }
+    private fun sumInntekt(): Double = arbeidsforhold.sumOf { BigDecimal.valueOf(it.inntekt) }.toDouble()
 }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/utils/FeiletValidering.kt
@@ -29,11 +29,10 @@ internal object Feilmelding {
 
     const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MED_LIK_LOENN = "Ved innsending av flere arbeidsforhold må de ha ulik lønn"
     const val UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE = "Ved innsending av flere arbeidsforhold kan det ikke være sykefravær fra alle"
-    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_IKKE_TOM = "Må inneholde minst én fra-og-med-dato med flere arbeidsforhold"
-    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_MINST_TO = "Flere arbeidsforhold må inneholde minst to arbeidsforhold per dato"
-    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INGEN_ARBEIDSFORHOLD = "Minst ett arbeidsforhold må være inkludert i sykepengegrunnlaget per dato"
-    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_ALLE_ARBEIDSFORHOLD = "Kan ikke inkludere alle arbeidsforhold per dato, bruk vanlig inntektsmelding"
-    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INNTEKT_AVVIK = "Summen av inntekter fra flere arbeidsforhold må være lik innrapportert inntekt"
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_MINST_TO = "Flere arbeidsforhold må inneholde minst to arbeidsforhold per dato"
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_INGEN_ARBEIDSFORHOLD = "Minst ett arbeidsforhold må være inkludert i sykepengegrunnlaget per dato"
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_ALLE_ARBEIDSFORHOLD = "Kan ikke inkludere alle arbeidsforhold per dato, bruk vanlig inntektsmelding"
+    const val UGYLDIG_FLERE_ARBEIDSFORHOLD_INNTEKT_AVVIK = "Summen av inntekter fra flere arbeidsforhold må være lik innrapportert inntekt"
     const val UGYLDIG_ARBEIDSFORHOLD_YRKESBESKRIVELSE = "Yrkesbeskrivelse er ugyldig"
     const val UGYLDIG_ARBEIDSFORHOLD_STILLINGSPROSENT = "Stillingsprosent må være mellom 0 og 100"
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/FlereArbeidsforholdTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/FlereArbeidsforholdTest.kt
@@ -7,8 +7,6 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.FeiletValidering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.Feilmelding
-import no.nav.helsearbeidsgiver.utils.test.date.juni
-import no.nav.helsearbeidsgiver.utils.test.date.mai
 
 class FlereArbeidsforholdTest :
     FunSpec({
@@ -35,27 +33,15 @@ class FlereArbeidsforholdTest :
             flere.valider() shouldContainExactly listOf(FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_SYK_FRA_ALLE))
         }
 
-        test("Må ha minst én dato med flere arbeidsforhold") {
-            val flere =
-                TestData.flereArbeidsforhold.copy(
-                    arbeidsforholdPerSykmeldingStartdato = emptyMap(),
-                )
-
-            flere.valider() shouldContainExactly listOf(FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_IKKE_TOM))
-        }
-
         test("Må ha minst to arbeidsforhold") {
             val flere =
                 TestData.flereArbeidsforhold.copy(
-                    arbeidsforholdPerSykmeldingStartdato =
-                        mapOf(
-                            11.mai to listOf(TestData.lagArbeidsforhold().copy(inkludertISykefravaer = true)),
-                        ),
+                    arbeidsforhold = listOf(TestData.lagArbeidsforhold().copy(inkludertISykefravaer = true)),
                 )
             flere.valider() shouldContainExactly
                 listOf(
-                    FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_MINST_TO),
-                    FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_ALLE_ARBEIDSFORHOLD),
+                    FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MINST_TO),
+                    FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_ALLE_ARBEIDSFORHOLD),
                 )
         }
 
@@ -67,14 +53,12 @@ class FlereArbeidsforholdTest :
                 listOf(true, false, false) to emptySet(),
                 listOf(false, true, false) to emptySet(),
                 listOf(true, true, false) to emptySet(),
-                listOf(true, true, true) to setOf(FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_ALLE_ARBEIDSFORHOLD)),
-                listOf(false, false, false) to setOf(FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INGEN_ARBEIDSFORHOLD)),
+                listOf(true, true, true) to setOf(FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_ALLE_ARBEIDSFORHOLD)),
+                listOf(false, false, false) to setOf(FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_INGEN_ARBEIDSFORHOLD)),
             ) { (inkluderte, forventetFeil) ->
-                val arbeidsforhold = inkluderte.map { TestData.lagArbeidsforhold().copy(inkludertISykefravaer = it) }.toList()
-
                 val flereArbeidsforhold =
                     TestData.flereArbeidsforhold.copy(
-                        arbeidsforholdPerSykmeldingStartdato = mapOf(20.juni to arbeidsforhold),
+                        arbeidsforhold = inkluderte.map { TestData.lagArbeidsforhold().copy(inkludertISykefravaer = it) },
                     )
 
                 flereArbeidsforhold.valider() shouldBe forventetFeil

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/TestData.kt
@@ -79,47 +79,29 @@ object TestData {
         FlereArbeidsforhold(
             harLikLoenn = false,
             erSykmeldtFraAlle = false,
-            arbeidsforholdPerSykmeldingStartdato =
-                mapOf(
-                    11.mai to
-                        listOf(
-                            Arbeidsforhold(
-                                inkludertISykefravaer = true,
-                                yrkesbeskrivelse = "Snekker",
-                                stillingsprosent = 40.0,
-                                inntekt = 20_000.0,
-                            ),
-                            Arbeidsforhold(
-                                inkludertISykefravaer = false,
-                                yrkesbeskrivelse = "Stuntmann",
-                                stillingsprosent = 40.0,
-                                inntekt = 30_000.0,
-                            ),
-                        ),
-                    20.juni to
-                        listOf(
-                            Arbeidsforhold(
-                                inkludertISykefravaer = true,
-                                yrkesbeskrivelse = "Snekker",
-                                stillingsprosent = 70.0,
-                                inntekt = 40_000.0,
-                            ),
-                            Arbeidsforhold(
-                                inkludertISykefravaer = false,
-                                yrkesbeskrivelse = "Stuntmann",
-                                stillingsprosent = 40.0,
-                                inntekt = 10_000.0,
-                            ),
-                        ),
+            arbeidsforhold =
+                listOf(
+                    Arbeidsforhold(
+                        inkludertISykefravaer = true,
+                        yrkesbeskrivelse = "Snekker",
+                        stillingsprosent = 40.0,
+                        inntekt = 20_000.0,
+                    ),
+                    Arbeidsforhold(
+                        inkludertISykefravaer = false,
+                        yrkesbeskrivelse = "Stuntmann",
+                        stillingsprosent = 40.0,
+                        inntekt = 30_000.0,
+                    ),
                 ),
         )
 
     val flereArbeidsforholdMedUgyldigInntekt =
         flereArbeidsforhold.copy(
-            arbeidsforholdPerSykmeldingStartdato =
-                flereArbeidsforhold.arbeidsforholdPerSykmeldingStartdato.mapValues { (startdato, arbeidsforhold) ->
-                    if (startdato == 20.juni) {
-                        arbeidsforhold.map { it.copy(inntekt = 30_000.0) }
+            arbeidsforhold =
+                flereArbeidsforhold.arbeidsforhold.mapIndexed { index, arbeidsforhold ->
+                    if (index == 0) {
+                        arbeidsforhold.copy(inntekt = 40_000.0)
                     } else {
                         arbeidsforhold
                     }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingSelvbestemtTest.kt
@@ -402,7 +402,7 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                                 FlereArbeidsforhold(
                                     harLikLoenn = true,
                                     erSykmeldtFraAlle = true,
-                                    arbeidsforholdPerSykmeldingStartdato = emptyMap(),
+                                    arbeidsforhold = emptyList(),
                                 ),
                         )
 
@@ -419,7 +419,7 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                             )
                         }
 
-                    skjema.valider() shouldContainExactly setOf(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INNTEKT_AVVIK)
+                    skjema.valider() shouldContainExactly setOf(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_INNTEKT_AVVIK)
                 }
 
                 context("flere arbeidsforhold uten arbeidsforholdstype 'med arbeidsforhold' er _ikke_ gyldig") {
@@ -576,36 +576,20 @@ class SkjemaInntektsmeldingSelvbestemtTest :
                     {
                         "harLikLoenn": false,
                         "erSykmeldtFraAlle": false,
-                        "arbeidsforholdPerSykmeldingStartdato": {
-                            "2018-05-11": [
-                                {
-                                    "inkludertISykefravaer": true,
-                                    "yrkesbeskrivelse": "Snekker",
-                                    "stillingsprosent": 40.0,
-                                    "inntekt": 20000.0
-                                },
-                                {
-                                    "inkludertISykefravaer": false,
-                                    "yrkesbeskrivelse": "Stuntmann",
-                                    "stillingsprosent": 40.0,
-                                    "inntekt": 30000.0
-                                }
-                            ],
-                            "2018-06-20": [
-                                {
-                                    "inkludertISykefravaer": true,
-                                    "yrkesbeskrivelse": "Snekker",
-                                    "stillingsprosent": 70.0,
-                                    "inntekt": 40000.0
-                                },
-                                {
-                                    "inkludertISykefravaer": false,
-                                    "yrkesbeskrivelse": "Stuntmann",
-                                    "stillingsprosent": 40.0,
-                                    "inntekt": 10000.0
-                                }
-                            ]
-                        }
+                        "arbeidsforhold": [
+                            {
+                                "inkludertISykefravaer": true,
+                                "yrkesbeskrivelse": "Snekker",
+                                "stillingsprosent": 40.0,
+                                "inntekt": 20000.0
+                            },
+                            {
+                                "inkludertISykefravaer": false,
+                                "yrkesbeskrivelse": "Stuntmann",
+                                "stillingsprosent": 40.0,
+                                "inntekt": 30000.0
+                            }
+                        ]
                     }
                     """.removeJsonWhitespace()
 

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/domene/inntektsmelding/v1/skjema/SkjemaInntektsmeldingTest.kt
@@ -334,9 +334,9 @@ class SkjemaInntektsmeldingTest :
                         FlereArbeidsforhold(
                             harLikLoenn = false,
                             erSykmeldtFraAlle = false,
-                            arbeidsforholdPerSykmeldingStartdato = emptyMap(),
+                            arbeidsforhold = emptyList(),
                         )
-                    ugyldig.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_IKKE_TOM)
+                    ugyldig.valider() shouldContain FeiletValidering(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_MINST_TO)
                 }
 
                 test("Sum av inntektene fra flere arbeidsforhold kan ikke være forskjellig fra rapportert inntekt") {
@@ -352,7 +352,7 @@ class SkjemaInntektsmeldingTest :
                             flereArbeidsforhold = TestData.flereArbeidsforholdMedUgyldigInntekt,
                         )
 
-                    skjema.valider() shouldContainAll setOf(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_PER_STARTDATO_INNTEKT_AVVIK)
+                    skjema.valider() shouldContainAll setOf(Feilmelding.UGYLDIG_FLERE_ARBEIDSFORHOLD_INNTEKT_AVVIK)
                 }
             }
 


### PR DESCRIPTION
Reverter hoveddelene av https://github.com/navikt/hag-domene-inntektsmelding/pull/74.

Etter en diskusjon med SAS-gjengen så kom vi frem til at vi ikke trenger å ha med endringer for flere arbeidsforhold.